### PR TITLE
feat: Add blue plus button to queue cards in search modal

### DIFF
--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -89,6 +89,7 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
             <div className="song-title">{service} {i + 1}</div>
             <div className="artist-name">{service} Artist {i + 1}</div>
           </div>
+          <button className="add-to-queue-button">+</button>
           <div className="service-info">{service}</div>
         </div>
       ))}

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1026,3 +1026,27 @@ transform: scale(1.02);
   overflow: hidden;
 }
 
+.queue-card {
+  position: relative; /* Ensure the button can be positioned relative to the card */
+}
+
+.add-to-queue-button {
+  position: absolute;
+  top: 5px; /* Adjust as needed */
+  right: 5px; /* Adjust as needed */
+  background-color: #007bff; /* Blue background */
+  color: white;
+  border: none;
+  border-radius: 50%; /* Circular button */
+  width: 20px; /* Adjust as needed */
+  height: 20px; /* Adjust as needed */
+  font-size: 14px; /* Adjust as needed */
+  line-height: 18px; /* Center the plus icon */
+  text-align: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+.add-to-queue-button:hover {
+  background-color: #0056b3; /* Darker blue on hover */
+}


### PR DESCRIPTION
This commit introduces a new feature: a blue plus button on each queue card within the search results modal.

The button is positioned in the top-right corner of the card and is styled with a blue background, white plus symbol, and rounded corners.

Changes include:
- Added HTML for the button in `Harmonize/src/components/TopBar.jsx`.
- Added CSS for styling and positioning the button in `Harmonize/src/styles.css`.