### PR TITLE
Enable drag and drop queue ordering

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -1,27 +1,34 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { DndContext, closestCenter } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
 import YouTubeLogo from '../assets/youtube.png';
 import SoundCloudLogo from '../assets/soundcloud.svg';
 import SpotifyLogo from '../assets/spotify.svg';
+import SortableQueueItem from './SortableQueueItem.jsx';
 
-const queueData = [
-  { albumCover: 'https://via.placeholder.com/60', title: 'Midnight Pulse', artist: 'Luna Waves', serviceLogo: SpotifyLogo, queuedBy: 'Jake' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Skyline Dreams', artist: 'Nova Drive', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Neon Nightfall', artist: 'Echo Riders', serviceLogo: SoundCloudLogo, queuedBy: 'Jess' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Synth Horizon', artist: 'Retro Nova', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Solar Drift', artist: 'Galaxy Flow', serviceLogo: YouTubeLogo, queuedBy: 'Zane' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Electric Fade', artist: 'Vaporline', serviceLogo: SoundCloudLogo, queuedBy: 'Jake' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Golden Hour', artist: 'Sunset Run', serviceLogo: SpotifyLogo, queuedBy: 'Jess' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Ocean Drive', artist: 'Coral Keys', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Pulse Shift', artist: 'Tempo Blaze', serviceLogo: SoundCloudLogo, queuedBy: 'Zane' },
-  { albumCover: 'https://via.placeholder.com/60', title: 'Static Bloom', artist: 'Signal Bloom', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
+const initialQueue = [
+  { id: '1', albumCover: 'https://via.placeholder.com/60', title: 'Midnight Pulse', artist: 'Luna Waves', serviceLogo: SpotifyLogo, queuedBy: 'Jake' },
+  { id: '2', albumCover: 'https://via.placeholder.com/60', title: 'Skyline Dreams', artist: 'Nova Drive', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
+  { id: '3', albumCover: 'https://via.placeholder.com/60', title: 'Neon Nightfall', artist: 'Echo Riders', serviceLogo: SoundCloudLogo, queuedBy: 'Jess' },
+  { id: '4', albumCover: 'https://via.placeholder.com/60', title: 'Synth Horizon', artist: 'Retro Nova', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
+  { id: '5', albumCover: 'https://via.placeholder.com/60', title: 'Solar Drift', artist: 'Galaxy Flow', serviceLogo: YouTubeLogo, queuedBy: 'Zane' },
+  { id: '6', albumCover: 'https://via.placeholder.com/60', title: 'Electric Fade', artist: 'Vaporline', serviceLogo: SoundCloudLogo, queuedBy: 'Jake' },
+  { id: '7', albumCover: 'https://via.placeholder.com/60', title: 'Golden Hour', artist: 'Sunset Run', serviceLogo: SpotifyLogo, queuedBy: 'Jess' },
+  { id: '8', albumCover: 'https://via.placeholder.com/60', title: 'Ocean Drive', artist: 'Coral Keys', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
+  { id: '9', albumCover: 'https://via.placeholder.com/60', title: 'Pulse Shift', artist: 'Tempo Blaze', serviceLogo: SoundCloudLogo, queuedBy: 'Zane' },
+  { id: '10', albumCover: 'https://via.placeholder.com/60', title: 'Static Bloom', artist: 'Signal Bloom', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
 ];
 
 export default function RightSidebar({isVisible}) {
-  const [isOpen, setIsOpen] = useState(true);
   const [width, setWidth] = useState(300);
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
+  const [queue, setQueue] = useState(initialQueue);
 
   useEffect(() => {
     const handleMouseMove = (e) => {
@@ -45,41 +52,45 @@ export default function RightSidebar({isVisible}) {
       window.removeEventListener('mouseup', stopResize);
     };
   }, []);
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setQueue((items) => {
+        const oldIndex = items.findIndex((i) => i.id === active.id);
+        const newIndex = items.findIndex((i) => i.id === over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
   return (
     <div
       className="right-sidebar"
       style={{
         width: isVisible ? width : 0,
         opacity: isVisible ? 1 : 0,
-        pointerEvents: isVisible ? 'auto' : 'none'
+        pointerEvents: isVisible ? 'auto' : 'none',
       }}
     >
       <div
         className="sidebar-left-edge"
         onMouseDown={() => (isResizing.current = true)}
       />
-  
+
       <div className="sidebar-section">
         <h2 className="sidebar-title">Shared Queue</h2>
       </div>
-  
-      {queueData.map((item, idx) => (
-        <div className="queue-card" key={idx}>
-          <div className="album-cover-placeholder" />
-          <div className="song-info">
-            <div className="song-title">{item.title}</div>
-            <div className="artist-name">{item.artist}</div>
-          </div>
-          <div className="service-info">
-            <img
-              src={item.serviceLogo}
-              alt="service"
-              style={{ width: 20, height: 20, marginBottom: 4 }}
-            />
-            <div className="queued-by">{item.queuedBy}</div>
-          </div>
-        </div>
-      ))}
+
+      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext
+          items={queue.map((q) => q.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {queue.map((item) => (
+            <SortableQueueItem key={item.id} id={item.id} item={item} />
+          ))}
+        </SortableContext>
+      </DndContext>
     </div>
-  );  
+  );
 }

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+export default function SortableQueueItem({ id, item }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    cursor: isDragging ? 'grabbing' : 'grab',
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="queue-card" {...attributes} {...listeners}>
+      <div className="album-cover-placeholder" />
+      <div className="song-info">
+        <div className="song-title">{item.title}</div>
+        <div className="artist-name">{item.artist}</div>
+      </div>
+      <div className="service-info">
+        <img
+          src={item.serviceLogo}
+          alt="service"
+          style={{ width: 20, height: 20, marginBottom: 4 }}
+        />
+        <div className="queued-by">{item.queuedBy}</div>
+      </div>
+    </div>
+  );
+}

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -700,7 +700,7 @@ transform: scale(1.02);
   font-size: 14px;
   gap: 8px;
   transition: background-color 0.2s ease, transform 0.1s ease;
-  cursor: pointer;
+  cursor: grab;
 }
 
 .queue-card:hover {
@@ -710,6 +710,7 @@ transform: scale(1.02);
 .queue-card:active {
   transform: scale(0.98);
   background-color: #3b3b3b;
+  cursor: grabbing;
 }
 
 .album-cover {
@@ -1028,6 +1029,7 @@ transform: scale(1.02);
 
 .queue-card {
   position: relative; /* Ensure the button can be positioned relative to the card */
+  cursor: grab;
 }
 
 .add-to-queue-button {


### PR DESCRIPTION
## Summary
- add SortableQueueItem component using dnd-kit
- update RightSidebar to allow reordering the queue via drag and drop
- tweak queue card styles for draggable feedback

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840d69089c8832b8c4c096fbba6c823