### PR TITLE
Separate modal cards from queue

### DIFF
--- a/Harmonize/src/components/SearchResultCard.jsx
+++ b/Harmonize/src/components/SearchResultCard.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function SearchResultCard({ title, artist, service, onAdd }) {
+  return (
+    <div className="result-card">
+      <div className="album-cover-placeholder" />
+      <div className="song-info">
+        <div className="song-title">{title}</div>
+        <div className="artist-name">{artist}</div>
+      </div>
+      <button className="add-to-queue-button" onClick={onAdd}>+</button>
+      <div className="service-info">{service}</div>
+    </div>
+  );
+}

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import SearchResultCard from './SearchResultCard.jsx';
 
 export default function TopBar() {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -78,24 +79,22 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
 
 
           <h2 className="modal-title">Search Results</h2>
-<div className="multi-column-results">
-  {activeServices.map((service) => (
-    <div key={service} className="service-column">
-      <h3 className="service-header">{service}</h3>
-      {Array.from({ length: 10 }, (_, i) => (
-        <div key={i} className="queue-card">
-          <div className="album-cover-placeholder"></div>
-          <div className="song-info">
-            <div className="song-title">{service} {i + 1}</div>
-            <div className="artist-name">{service} Artist {i + 1}</div>
-          </div>
-          <button className="add-to-queue-button">+</button>
-          <div className="service-info">{service}</div>
-        </div>
-      ))}
-    </div>
-  ))}
-</div>
+  <div className="multi-column-results">
+    {activeServices.map((service) => (
+      <div key={service} className="service-column">
+        <h3 className="service-header">{service}</h3>
+        {Array.from({ length: 10 }, (_, i) => (
+          <SearchResultCard
+            key={i}
+            title={`${service} ${i + 1}`}
+            artist={`${service} Artist ${i + 1}`}
+            service={service}
+            onAdd={() => {}}
+          />
+        ))}
+      </div>
+    ))}
+  </div>
 
                 </div>
      

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -713,6 +713,18 @@ transform: scale(1.02);
   cursor: grabbing;
 }
 
+.result-card {
+  display: flex;
+  align-items: center;
+  background-color: #1e1e1e;
+  padding: 8px 12px;
+  border: 1px solid #333;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  gap: 8px;
+}
+
 .album-cover {
   width: 60px;
   height: 60px;
@@ -1027,9 +1039,9 @@ transform: scale(1.02);
   overflow: hidden;
 }
 
-.queue-card {
+.result-card {
   position: relative; /* Ensure the button can be positioned relative to the card */
-  cursor: grab;
+  cursor: default;
 }
 
 .add-to-queue-button {


### PR DESCRIPTION
## Summary
- isolate queue items shown in the modal from those in the sidebar queue
- add `SearchResultCard` component for modal results
- adjust `TopBar` to use the new component
- update styles for `.result-card`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840db51be2c832b99045c30413a9d2a