### PR TITLE
Add play-next button to search result cards

### DIFF
--- a/Harmonize/src/components/SearchResultCard.jsx
+++ b/Harmonize/src/components/SearchResultCard.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
-export default function SearchResultCard({ title, artist, service, onAdd }) {
+export default function SearchResultCard({
+  title,
+  artist,
+  service,
+  onAdd,
+  onPlayNext,
+}) {
   return (
     <div className="result-card">
       <div className="album-cover-placeholder" />
@@ -8,8 +14,11 @@ export default function SearchResultCard({ title, artist, service, onAdd }) {
         <div className="song-title">{title}</div>
         <div className="artist-name">{artist}</div>
       </div>
-      <button className="add-to-queue-button" onClick={onAdd}>+</button>
       <div className="service-info">{service}</div>
+      <div className="action-buttons">
+        <button className="add-to-queue-button" onClick={onAdd}>+</button>
+        <button className="play-next-button" onClick={onPlayNext}>↑</button>
+      </div>
     </div>
   );
 }

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -90,6 +90,7 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
             artist={`${service} Artist ${i + 1}`}
             service={service}
             onAdd={() => {}}
+            onPlayNext={() => {}}
           />
         ))}
       </div>

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1040,27 +1040,33 @@ transform: scale(1.02);
 }
 
 .result-card {
-  position: relative; /* Ensure the button can be positioned relative to the card */
+  position: relative;
   cursor: default;
 }
 
-.add-to-queue-button {
-  position: absolute;
-  top: 5px; /* Adjust as needed */
-  right: 5px; /* Adjust as needed */
-  background-color: #007bff; /* Blue background */
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.add-to-queue-button,
+.play-next-button {
+  background-color: #007bff;
   color: white;
   border: none;
-  border-radius: 50%; /* Circular button */
-  width: 20px; /* Adjust as needed */
-  height: 20px; /* Adjust as needed */
-  font-size: 14px; /* Adjust as needed */
-  line-height: 18px; /* Center the plus icon */
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  font-size: 14px;
+  line-height: 18px;
   text-align: center;
   cursor: pointer;
   padding: 0;
 }
 
-.add-to-queue-button:hover {
-  background-color: #0056b3; /* Darker blue on hover */
+.add-to-queue-button:hover,
+.play-next-button:hover {
+  background-color: #0056b3;
 }


### PR DESCRIPTION
## Summary
- add a second action button on each SearchResultCard
- allow passing `onPlayNext` handler
- style vertical action buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840ddf68acc832b92190be18c058fb6