### PR TITLE
Add click animation to queue & next buttons

### DIFF
--- a/Harmonize/src/components/SearchResultCard.jsx
+++ b/Harmonize/src/components/SearchResultCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function SearchResultCard({
   title,
@@ -7,6 +7,32 @@ export default function SearchResultCard({
   onAdd,
   onPlayNext,
 }) {
+  const [addClicked, setAddClicked] = useState(false);
+  const [nextClicked, setNextClicked] = useState(false);
+
+  useEffect(() => {
+    if (addClicked) {
+      const timer = setTimeout(() => setAddClicked(false), 200);
+      return () => clearTimeout(timer);
+    }
+  }, [addClicked]);
+
+  useEffect(() => {
+    if (nextClicked) {
+      const timer = setTimeout(() => setNextClicked(false), 200);
+      return () => clearTimeout(timer);
+    }
+  }, [nextClicked]);
+
+  const handleAdd = () => {
+    setAddClicked(true);
+    onAdd();
+  };
+
+  const handlePlayNext = () => {
+    setNextClicked(true);
+    onPlayNext();
+  };
   return (
     <div className="result-card">
       <div className="album-cover-placeholder" />
@@ -16,8 +42,18 @@ export default function SearchResultCard({
       </div>
       <div className="service-info">{service}</div>
       <div className="action-buttons">
-        <button className="add-to-queue-button" onClick={onAdd}>+</button>
-        <button className="play-next-button" onClick={onPlayNext}>↑</button>
+        <button
+          className={`add-to-queue-button${addClicked ? ' clicked' : ''}`}
+          onClick={handleAdd}
+        >
+          +
+        </button>
+        <button
+          className={`play-next-button${nextClicked ? ' clicked' : ''}`}
+          onClick={handlePlayNext}
+        >
+          ↑
+        </button>
       </div>
     </div>
   );

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1070,3 +1070,20 @@ transform: scale(1.02);
 .play-next-button:hover {
   background-color: #0056b3;
 }
+
+.add-to-queue-button.clicked,
+.play-next-button.clicked {
+  animation: button-click 0.2s ease;
+}
+
+@keyframes button-click {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(0.85);
+  }
+  100% {
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Summary
- animate queue and next buttons on click in the modal
- add CSS animation for clicked effect

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e181d7fc832bbd9606a92ecd9aa4