### PR TITLE
Add scrolling to queue sidebar

### DIFF
--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1037,7 +1037,8 @@ transform: scale(1.02);
 
 .right-sidebar {
   transition: width 0.2s ease, opacity 0.2s ease;
-  overflow: hidden;
+  overflow-y: auto;
+  height: 100%;
 }
 
 .result-card {


### PR DESCRIPTION
## Summary
- allow the queue sidebar to scroll vertically when it overflows

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840e7209dd4832bac0e87c57bfdad2b