### PR TITLE
Fix right sidebar collapse animation

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -190,22 +190,12 @@ function App() {
           </main>
 
           <div
-  className="right-sidebar-container"
-  style={{
-    width: isRightSidebarVisible ? 'auto' : '0',
-    transition: 'width 0.3s ease'
-  }}
->
-  <div
-    className={`right-sidebar-slide ${isRightSidebarVisible ? 'slide-in' : 'slide-out'}`}
-    style={{
-      width: isRightSidebarVisible ? undefined : 0,
-      overflow: 'hidden'
-    }}
-  >
-    <RightSidebar isVisible={isRightSidebarVisible} />
-  </div>
-</div>
+            className={`right-sidebar-container ${
+              isRightSidebarVisible ? 'slide-in' : 'slide-out'
+            }`}
+          >
+            <RightSidebar isVisible={isRightSidebarVisible} />
+          </div>
 
         </div>
       </div>


### PR DESCRIPTION
## Summary
- simplify right sidebar markup
- apply slide classes to the container so closing uses the same animation

## Testing
- `npm run lint --prefix Harmonize`

------
https://chatgpt.com/codex/tasks/task_e_6840e754773c832bb9f22fe3e2981b9b