### PR TITLE
Fix right sidebar collapse animation

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -190,22 +190,17 @@ function App() {
           </main>
 
           <div
-  className="right-sidebar-container"
-  style={{
-    width: isRightSidebarVisible ? 'auto' : '0',
-    transition: 'width 0.3s ease'
-  }}
->
-  <div
-    className={`right-sidebar-slide ${isRightSidebarVisible ? 'slide-in' : 'slide-out'}`}
-    style={{
-      width: isRightSidebarVisible ? undefined : 0,
-      overflow: 'hidden'
-    }}
-  >
-    <RightSidebar isVisible={isRightSidebarVisible} />
-  </div>
-</div>
+            className={`right-sidebar-container ${
+              isRightSidebarVisible ? 'slide-in' : 'slide-out'
+            }`}
+            style={{
+              width: isRightSidebarVisible ? 'auto' : 0,
+              transition: 'width 0.3s ease',
+              overflow: 'hidden'
+            }}
+          >
+            <RightSidebar isVisible={isRightSidebarVisible} />
+          </div>
 
         </div>
       </div>

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1020,9 +1020,10 @@ transform: scale(1.02);
 
 .right-sidebar-container {
   display: flex;
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease, width 0.3s ease;
   height: 100%;
   position: relative;
+  overflow: hidden;
 }
 
 .right-sidebar-container.slide-in {


### PR DESCRIPTION
## Summary
- handle sidebar width so main content can expand
- smooth slide-in/out transitions with hidden overflow

## Testing
- `npm run lint --prefix Harmonize` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840e754773c832bb9f22fe3e2981b9b