### PR TITLE
Fix right sidebar collapsing layout

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -123,8 +123,8 @@ function App() {
           </div>
           </div>
 
-        {/* Main and Right Sidebar */}
-        <div className="main-and-right">
+        {/* Main Area */}
+        <div className="main-area">
           <div
             className="sidebar-handle left-handle"
             onClick={() => setIsLeftSidebarVisible(prev => !prev)}
@@ -189,15 +189,15 @@ function App() {
             </div>
           </main>
 
-          <div
-            className={`right-sidebar-container ${
-              isRightSidebarVisible ? 'slide-in' : 'slide-out'
-            }`}
-          >
-            <RightSidebar isVisible={isRightSidebarVisible} />
-          </div>
-
         </div>
+        <div
+          className={`right-sidebar-container ${
+            isRightSidebarVisible ? 'slide-in' : 'slide-out'
+          }`}
+        >
+          <RightSidebar isVisible={isRightSidebarVisible} />
+        </div>
+
       </div>
     </>
   );

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -652,13 +652,6 @@ transform: scale(1.02);
   margin: 0.5em auto;
 }
 
-.main-and-right {
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  flex: 1;
-  height: 100%;
-}
 
 .sidebar.left-sidebar .copy-button {
   margin-top: 0px;


### PR DESCRIPTION
## Summary
- remove `main-and-right` wrapper from the layout
- introduce new `main-area` container and move right sidebar outside of it
- drop unused `.main-and-right` CSS

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840eda5a108832ba9ed1ed682a76a18