### PR TITLE
Fix collapsed sidebar width issue

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -69,6 +69,7 @@ export default function RightSidebar({isVisible}) {
       style={{
         width: isVisible ? width : 0,
         minWidth: isVisible ? minWidth : 0,
+        padding: isVisible ? '10px' : 0,
         opacity: isVisible ? 1 : 0,
         pointerEvents: isVisible ? 'auto' : 'none',
       }}
@@ -76,6 +77,7 @@ export default function RightSidebar({isVisible}) {
       <div
         className="sidebar-left-edge"
         onMouseDown={() => (isResizing.current = true)}
+        style={{ display: isVisible ? 'block' : 'none' }}
       />
 
       <div className="sidebar-section">


### PR DESCRIPTION
## Summary
- fix leftover padding when RightSidebar collapses
- hide right sidebar resizer when collapsed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840f03c1a4c832baf0b2451e583bec6