### PR TITLE
Replace profile pic with account icon

### DIFF
--- a/Harmonize/src/components/UserCard.jsx
+++ b/Harmonize/src/components/UserCard.jsx
@@ -40,11 +40,10 @@ export default function UserCard({ user }) {
       <span className="username">{user.name}</span>
       {open && (
         <div className="contact-card" onPointerDown={(e) => e.stopPropagation()}>
-          <img
-            src={user.profilePic}
-            alt="profile"
-            className="contact-photo"
-          />
+          <div className="contact-icon">
+            <div className="head"></div>
+            <div className="body"></div>
+          </div>
           <div className="contact-name">{user.name}</div>
           <div className="contact-services">
             {user.services.map((s) => (

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -475,11 +475,28 @@ transform: scale(1.02);
     width: 160px;
   }
 
-  .contact-photo {
+  .contact-icon {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
     width: 60px;
     height: 60px;
-    object-fit: cover;
-    border-radius: 4px;
+  }
+
+  .contact-icon .head {
+    width: 20px;
+    height: 20px;
+    background-color: white;
+    border-radius: 50%;
+  }
+
+  .contact-icon .body {
+    width: 30px;
+    height: 16px;
+    background-color: white;
+    border-radius: 8px;
   }
 
   .contact-name {


### PR DESCRIPTION
## Summary
- replace profile photo on user cards with an enlarged account icon
- style the new user card icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841d68a2fd4832ba3e518a01a2241e9