### PR TITLE
Add welcome card to intro modal

### DIFF
--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -24,18 +24,32 @@ export default function RoomSetupModal({ onClose }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content setup-modal-content" onClick={(e) => e.stopPropagation()}>
         <button className="modal-close-button" onClick={onClose} aria-label="Close Modal">
           &times;
         </button>
         {mode === null && (
-          <div className="intro-buttons">
-            <button className="submit-link-button" onClick={() => setMode('create')}>
-              Create Listening Room
-            </button>
-            <button className="submit-link-button" onClick={() => setMode('join')}>
-              Join Listening Room
-            </button>
+          <div className="intro-card">
+            <img
+              src="/src/assets/logo.png"
+              alt="Harmonize Logo"
+              className="intro-logo"
+            />
+            <h2 className="intro-title">Welcome to Harmonize</h2>
+            <div className="intro-buttons">
+              <button
+                className="submit-link-button"
+                onClick={() => setMode('create')}
+              >
+                Create Listening Room
+              </button>
+              <button
+                className="submit-link-button"
+                onClick={() => setMode('join')}
+              >
+                Join Listening Room
+              </button>
+            </div>
           </div>
         )}
         {mode === 'create' && (

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1161,6 +1161,34 @@ transform: scale(1.02);
   max-width: 600px;
 }
 
+/* Room setup modal styling */
+.setup-modal-content {
+  max-width: 350px;
+  min-height: 500px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.intro-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.intro-logo {
+  width: 80px;
+  margin-bottom: 1rem;
+}
+
+.intro-title {
+  color: white;
+  font-size: 1.75rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
 /* Intro modal layout */
 .intro-buttons {
   display: flex;


### PR DESCRIPTION
## Summary
- style RoomSetupModal to look like a vertical card and display a welcome message
- include Harmonize logo and title in the intro modal

## Testing
- `npm --prefix Harmonize run lint`

------
https://chatgpt.com/codex/tasks/task_e_684610957130832b8b879f1d6e11df65