### PR TITLE
Enable clickable YouTube search cards

### DIFF
--- a/Harmonize/src/components/SearchResultCard.jsx
+++ b/Harmonize/src/components/SearchResultCard.jsx
@@ -5,21 +5,29 @@ export default function SearchResultCard({
   artist,
   service,
   thumbnail,
+  url,
   onAdd,
   onPlayNext,
 }) {
   return (
     <div className="result-card">
-      {thumbnail ? (
-        <img src={thumbnail} alt="thumbnail" className="album-cover" />
-      ) : (
-        <div className="album-cover-placeholder" />
-      )}
-      <div className="song-info">
-        <div className="song-title">{title}</div>
-        <div className="artist-name">{artist}</div>
-      </div>
-      <div className="service-info">{service}</div>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="result-link"
+      >
+        {thumbnail ? (
+          <img src={thumbnail} alt="thumbnail" className="album-cover" />
+        ) : (
+          <div className="album-cover-placeholder" />
+        )}
+        <div className="song-info">
+          <div className="song-title">{title}</div>
+          <div className="artist-name">{artist}</div>
+        </div>
+        <div className="service-info">{service}</div>
+      </a>
       <div className="action-buttons">
         <button className="add-to-queue-button" onClick={onAdd}>+</button>
         <button className="play-next-button" onClick={onPlayNext}>↑</button>

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -32,6 +32,7 @@ export default function TopBar() {
         title: item.snippet.title,
         artist: item.snippet.channelTitle,
         thumbnail: item.snippet.thumbnails?.default?.url,
+        url: `https://www.youtube.com/watch?v=${item.id.videoId}`,
       }));
       setYoutubeResults(results);
     } catch (err) {
@@ -147,6 +148,7 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
                 artist={r.artist}
                 service="YouTube"
                 thumbnail={r.thumbnail}
+                url={r.url}
                 onAdd={() => {}}
                 onPlayNext={() => {}}
               />

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -774,6 +774,15 @@ transform: scale(1.02);
   gap: 8px;
 }
 
+.result-link {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  gap: 8px;
+  text-decoration: none;
+  color: inherit;
+}
+
 .album-cover {
   width: 60px;
   height: 60px;
@@ -1093,6 +1102,15 @@ transform: scale(1.02);
 .result-card {
   position: relative;
   cursor: default;
+}
+
+.result-link {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  gap: 8px;
+  text-decoration: none;
+  color: inherit;
 }
 
 .action-buttons {


### PR DESCRIPTION
## Summary
- make YouTube search result cards link to the video
- expose video URL in search results mapping
- style anchor wrapper for cards

## Testing
- `npm run lint`
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_684759b56054832b8e908fb171b8e6ee