### PR TITLE
Link search result titles to source video

### DIFF
--- a/Harmonize/src/components/SearchResultCard.jsx
+++ b/Harmonize/src/components/SearchResultCard.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 export default function SearchResultCard({
   title,
   artist,
-  service,
   thumbnail,
   url,
   onAdd,
@@ -11,20 +10,25 @@ export default function SearchResultCard({
 }) {
   return (
     <div className="result-card">
-      {thumbnail ? (
-        <img src={thumbnail} alt="thumbnail" className="album-cover" />
-      ) : (
-        <div className="album-cover-placeholder" />
-      )}
-      <div className="song-info">
-        <div className="song-title">{title}</div>
-        <div className="artist-name">{artist}</div>
-      </div>
-      <div className="service-info">{service}</div>
+      <a
+        className="result-link"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {thumbnail ? (
+          <img src={thumbnail} alt="thumbnail" className="album-cover" />
+        ) : (
+          <div className="album-cover-placeholder" />
+        )}
+        <div className="song-info">
+          <div className="song-title">{title}</div>
+          <div className="artist-name">{artist}</div>
+        </div>
+      </a>
       <div className="action-buttons">
         <button className="add-to-queue-button" onClick={onAdd}>+</button>
         <button className="play-next-button" onClick={onPlayNext}>→</button>
-
       </div>
     </div>
   );

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -146,7 +146,6 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
                 key={r.id}
                 title={r.title}
                 artist={r.artist}
-                service="YouTube"
                 thumbnail={r.thumbnail}
                 url={r.url}
                 onAdd={() => {}}
@@ -158,7 +157,6 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
                 key={i}
                 title={`${service} ${i + 1}`}
                 artist={`${service} Artist ${i + 1}`}
-                service={service}
                 onAdd={() => {}}
                 onPlayNext={() => {}}
               />


### PR DESCRIPTION
## Summary
- make titles clickable links to the video on the SearchResultCard
- remove the service tag from search results
- adjust TopBar to match

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68475ce56064832b900fa997faa5ad27