### PR TITLE
Add show-more functionality to search modal

### DIFF
--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1160,6 +1160,27 @@ transform: scale(1.02);
   transition: background-color 0.2s ease, transform 0.1s ease;
 }
 
+.show-more-button {
+  background-color: #1e3a8a;
+  color: white;
+  border: none;
+  border-radius: 9999px;
+  padding: 4px 12px;
+  font-family: 'Roboto', sans-serif;
+  cursor: pointer;
+  margin: 8px auto 0;
+  width: fit-content;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.show-more-button:hover {
+  background-color: #3b82f6;
+}
+
+.show-more-button:active {
+  transform: scale(0.95);
+}
+
 .submit-link-button:hover {
   background-color: #0056b3;
 }


### PR DESCRIPTION
## Summary
- expand search states for Spotify and SoundCloud
- add pagination support for YouTube API
- implement placeholder search for Spotify and SoundCloud
- add `Show More` button for each service column
- style the new button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847635ae650832ba7711af456660d51