### PR TITLE
Use env var for YouTube API key

### DIFF
--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -10,7 +10,7 @@ export default function TopBar() {
   const [spotifyResults, setSpotifyResults] = useState([]);
   const [soundcloudResults, setSoundcloudResults] = useState([]);
   const [youtubeNextPageToken, setYoutubeNextPageToken] = useState(null);
-  const YOUTUBE_API_KEY = 'AIzaSyC3rXjyr82BiM5baC4ZmzyEQzITvmuCczM';
+  const YOUTUBE_API_KEY = import.meta.env.VITE_YOUTUBE_API_KEY;
 
   useEffect(() => {
     const handleKeyDown = (e) => {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The backend requires a `.env` file inside the `backend/` directory with the foll
 ```
 MONGO_URI=<MongoDB connection string>
 PORT=<port number for the API server>
+YOUTUBE_API_KEY=<YouTube API key>
 ```
 
 The `.env` file is excluded from version control via the root `.gitignore`.
+An example file `backend/.env.example` is provided to illustrate the expected
+variables.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+MONGO_URI=
+PORT=
+# YouTube API key used for search requests
+YOUTUBE_API_KEY=


### PR DESCRIPTION
## Summary
- move YouTube API key into environment variable
- document new `YOUTUBE_API_KEY` variable and provide `.env.example`

## Testing
- `npm install` *(fails: Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684b1cbdc87c832bb32b992414899a8f