### PR TITLE
Add Spotify search API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+!backend/.env

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -70,24 +70,25 @@ export default function TopBar() {
     }
   };
 
-  const searchSpotify = (query) => {
+  const searchSpotify = async (query, offset = 0) => {
     if (!query) return;
-    const results = Array.from({ length: 10 }, (_, i) => ({
-      id: `${query}-spotify-${i}`,
-      title: `${query} Spotify ${i + 1}`,
-      artist: `Spotify Artist ${i + 1}`,
-    }));
-    setSpotifyResults(results);
+    try {
+      const res = await fetch(
+        `http://localhost:3001/spotify/search?q=${encodeURIComponent(query)}&offset=${offset}`
+      );
+      const data = await res.json();
+      if (offset === 0) {
+        setSpotifyResults(data.tracks || []);
+      } else {
+        setSpotifyResults((prev) => [...prev, ...(data.tracks || [])]);
+      }
+    } catch (err) {
+      console.error('Spotify search error', err);
+    }
   };
 
   const loadMoreSpotify = () => {
-    const start = spotifyResults.length;
-    const more = Array.from({ length: 10 }, (_, i) => ({
-      id: `${searchQuery}-spotify-${start + i}`,
-      title: `${searchQuery} Spotify ${start + i + 1}`,
-      artist: `Spotify Artist ${start + i + 1}`,
-    }));
-    setSpotifyResults((prev) => [...prev, ...more]);
+    searchSpotify(searchQuery, spotifyResults.length);
   };
 
   const searchSoundCloud = (query) => {

--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,2 @@
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret

--- a/backend/index.js
+++ b/backend/index.js
@@ -4,6 +4,7 @@ import mongoose from 'mongoose';
 import dotenv from 'dotenv';
 import roomsRouter from './routes/rooms.js';
 import usersRouter from './routes/users.js';
+import spotifyRouter from './routes/spotify.js';
 
 
 
@@ -17,6 +18,7 @@ app.use(express.json());
 
 app.use('/rooms', roomsRouter);
 app.use('/users', usersRouter);
+app.use('/spotify', spotifyRouter);
 // MongoDB Connection
 mongoose.connect(process.env.MONGO_URI, {
   useNewUrlParser: true,
@@ -25,9 +27,6 @@ mongoose.connect(process.env.MONGO_URI, {
   .catch(err => console.error("❌ Mongo error:", err));
 
 // Routes
-app.use('/rooms', roomsRouter);
-
-app.use('/users', usersRouter);
 
 
 app.get('/test-db', async (req, res) => {

--- a/backend/routes/spotify.js
+++ b/backend/routes/spotify.js
@@ -1,0 +1,53 @@
+import express from 'express';
+
+let accessToken = null;
+let tokenExpiresAt = 0;
+
+async function getAccessToken() {
+  if (!accessToken || Date.now() >= tokenExpiresAt) {
+    const creds = `${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`;
+    const res = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Basic ' + Buffer.from(creds).toString('base64'),
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: 'grant_type=client_credentials'
+    });
+    const data = await res.json();
+    accessToken = data.access_token;
+    tokenExpiresAt = Date.now() + (data.expires_in - 60) * 1000; // refresh 1m early
+  }
+  return accessToken;
+}
+
+const router = express.Router();
+
+router.get('/search', async (req, res) => {
+  const query = req.query.q;
+  const offset = parseInt(req.query.offset || '0', 10);
+  if (!query) {
+    return res.status(400).json({ error: 'Missing q parameter' });
+  }
+  try {
+    const token = await getAccessToken();
+    const url = `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=track&limit=10&offset=${offset}`;
+    const resp = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const data = await resp.json();
+    const tracks = (data.tracks?.items || []).map((item) => ({
+      id: item.id,
+      title: item.name,
+      artist: item.artists.map((a) => a.name).join(', '),
+      thumbnail: item.album.images?.[item.album.images.length - 1]?.url || null,
+      url: item.external_urls?.spotify
+    }));
+    res.json({ tracks });
+  } catch (err) {
+    console.error('Spotify search error', err);
+    res.status(500).json({ error: 'Spotify search failed' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- integrate Spotify API with client credentials
- wire backend `/spotify/search` route
- call backend API from the React search bar
- track Spotify credentials in `backend/.env`
- allow backend `.env` in gitignore

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` in frontend (fails: missing ESLint dependencies)


------
https://chatgpt.com/codex/tasks/task_e_684b1d398bfc832b8e7bdf5fe1fd3763