### PR TITLE
Implement queue actions for search results

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -4,6 +4,9 @@ import React, { useState, useRef, useEffect } from 'react';
 import RightSidebar from './components/RightSidebar';
 import UserCard from './components/UserCard';
 import RoomSetupModal from './components/RoomSetupModal.jsx';
+import YouTubeLogo from './assets/youtube.png';
+import SoundCloudLogo from './assets/soundcloud.svg';
+import SpotifyLogo from './assets/spotify.svg';
 
 function App() {
   const [isLeftSidebarVisible, setIsLeftSidebarVisible] = useState(true);
@@ -77,6 +80,24 @@ function App() {
     },
   ];
 
+  const initialQueue = [
+    { id: '1', albumCover: 'https://via.placeholder.com/60', title: 'Midnight Pulse', artist: 'Luna Waves', serviceLogo: SpotifyLogo, queuedBy: 'Jake' },
+    { id: '2', albumCover: 'https://via.placeholder.com/60', title: 'Skyline Dreams', artist: 'Nova Drive', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
+    { id: '3', albumCover: 'https://via.placeholder.com/60', title: 'Neon Nightfall', artist: 'Echo Riders', serviceLogo: SoundCloudLogo, queuedBy: 'Jess' },
+    { id: '4', albumCover: 'https://via.placeholder.com/60', title: 'Synth Horizon', artist: 'Retro Nova', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
+    { id: '5', albumCover: 'https://via.placeholder.com/60', title: 'Solar Drift', artist: 'Galaxy Flow', serviceLogo: YouTubeLogo, queuedBy: 'Zane' },
+    { id: '6', albumCover: 'https://via.placeholder.com/60', title: 'Electric Fade', artist: 'Vaporline', serviceLogo: SoundCloudLogo, queuedBy: 'Jake' },
+    { id: '7', albumCover: 'https://via.placeholder.com/60', title: 'Golden Hour', artist: 'Sunset Run', serviceLogo: SpotifyLogo, queuedBy: 'Jess' },
+    { id: '8', albumCover: 'https://via.placeholder.com/60', title: 'Ocean Drive', artist: 'Coral Keys', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
+    { id: '9', albumCover: 'https://via.placeholder.com/60', title: 'Pulse Shift', artist: 'Tempo Blaze', serviceLogo: SoundCloudLogo, queuedBy: 'Zane' },
+    { id: '10', albumCover: 'https://via.placeholder.com/60', title: 'Static Bloom', artist: 'Signal Bloom', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
+  ];
+
+  const [queue, setQueue] = useState(initialQueue);
+
+  const addToQueueTop = (item) => setQueue((prev) => [item, ...prev]);
+  const addToQueueBottom = (item) => setQueue((prev) => [...prev, item]);
+
   const handleSeekStart = (e) => {
     setIsSeeking(true);
     updateSeek(e);
@@ -118,7 +139,7 @@ function App() {
   return (
     <>
       {showRoomModal && <RoomSetupModal onClose={() => setShowRoomModal(false)} />}
-      <TopBar />
+      <TopBar addToQueueTop={addToQueueTop} addToQueueBottom={addToQueueBottom} />
       <div className="app-layout">
         {/* Left Sidebar */}
 <div
@@ -222,7 +243,11 @@ function App() {
             isRightSidebarVisible ? 'slide-in' : 'slide-out'
           }`}
         >
-          <RightSidebar isVisible={isRightSidebarVisible} />
+          <RightSidebar
+            isVisible={isRightSidebarVisible}
+            queue={queue}
+            setQueue={setQueue}
+          />
         </div>
 
       </div>

--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -5,30 +5,13 @@ import {
   verticalListSortingStrategy,
   arrayMove,
 } from '@dnd-kit/sortable';
-import YouTubeLogo from '../assets/youtube.png';
-import SoundCloudLogo from '../assets/soundcloud.svg';
-import SpotifyLogo from '../assets/spotify.svg';
 import SortableQueueItem from './SortableQueueItem.jsx';
 
-const initialQueue = [
-  { id: '1', albumCover: 'https://via.placeholder.com/60', title: 'Midnight Pulse', artist: 'Luna Waves', serviceLogo: SpotifyLogo, queuedBy: 'Jake' },
-  { id: '2', albumCover: 'https://via.placeholder.com/60', title: 'Skyline Dreams', artist: 'Nova Drive', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
-  { id: '3', albumCover: 'https://via.placeholder.com/60', title: 'Neon Nightfall', artist: 'Echo Riders', serviceLogo: SoundCloudLogo, queuedBy: 'Jess' },
-  { id: '4', albumCover: 'https://via.placeholder.com/60', title: 'Synth Horizon', artist: 'Retro Nova', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
-  { id: '5', albumCover: 'https://via.placeholder.com/60', title: 'Solar Drift', artist: 'Galaxy Flow', serviceLogo: YouTubeLogo, queuedBy: 'Zane' },
-  { id: '6', albumCover: 'https://via.placeholder.com/60', title: 'Electric Fade', artist: 'Vaporline', serviceLogo: SoundCloudLogo, queuedBy: 'Jake' },
-  { id: '7', albumCover: 'https://via.placeholder.com/60', title: 'Golden Hour', artist: 'Sunset Run', serviceLogo: SpotifyLogo, queuedBy: 'Jess' },
-  { id: '8', albumCover: 'https://via.placeholder.com/60', title: 'Ocean Drive', artist: 'Coral Keys', serviceLogo: YouTubeLogo, queuedBy: 'Sofia' },
-  { id: '9', albumCover: 'https://via.placeholder.com/60', title: 'Pulse Shift', artist: 'Tempo Blaze', serviceLogo: SoundCloudLogo, queuedBy: 'Zane' },
-  { id: '10', albumCover: 'https://via.placeholder.com/60', title: 'Static Bloom', artist: 'Signal Bloom', serviceLogo: SpotifyLogo, queuedBy: 'Pranav' },
-];
-
-export default function RightSidebar({isVisible}) {
+export default function RightSidebar({ isVisible, queue, setQueue }) {
   const [width, setWidth] = useState(300);
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
-  const [queue, setQueue] = useState(initialQueue);
 
   useEffect(() => {
     const handleMouseMove = (e) => {

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import SearchResultCard from './SearchResultCard.jsx';
+import YouTubeLogo from '../assets/youtube.png';
+import SoundCloudLogo from '../assets/soundcloud.svg';
+import SpotifyLogo from '../assets/spotify.svg';
 
-export default function TopBar() {
+export default function TopBar({ addToQueueTop, addToQueueBottom }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [linkInput, setLinkInput] = useState('');
@@ -125,14 +128,29 @@ export default function TopBar() {
     setSoundcloudResults((prev) => [...prev, ...more]);
   };
 
-  const handleShowMore = (service) => {
-    if (service === 'YouTube') loadMoreYouTube();
-    if (service === 'Spotify') loadMoreSpotify();
-    if (service === 'SoundCloud') loadMoreSoundCloud();
+const handleShowMore = (service) => {
+  if (service === 'YouTube') loadMoreYouTube();
+  if (service === 'Spotify') loadMoreSpotify();
+  if (service === 'SoundCloud') loadMoreSoundCloud();
+};
+
+// Hardcoded for now; can be updated dynamically later
+const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this array to control visible columns
+
+  const serviceLogoMap = {
+    YouTube: YouTubeLogo,
+    Spotify: SpotifyLogo,
+    SoundCloud: SoundCloudLogo,
   };
 
-  // Hardcoded for now; can be updated dynamically later
-const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this array to control visible columns
+  const createQueueItem = (result, service) => ({
+    id: Date.now().toString(),
+    albumCover: result.thumbnail || 'https://via.placeholder.com/60',
+    title: result.title,
+    artist: result.artist,
+    serviceLogo: serviceLogoMap[service],
+    queuedBy: 'Pranav',
+  });
 
   return (
     <>
@@ -235,8 +253,8 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
               artist={r.artist}
               thumbnail={r.thumbnail}
               url={r.url}
-              onAdd={() => {}}
-              onPlayNext={() => {}}
+              onAdd={() => addToQueueBottom(createQueueItem(r, 'YouTube'))}
+              onPlayNext={() => addToQueueTop(createQueueItem(r, 'YouTube'))}
             />
           ))}
         {service === 'Spotify' &&
@@ -247,8 +265,8 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
               artist={r.artist}
               thumbnail={r.thumbnail}
               url={r.url}
-              onAdd={() => {}}
-              onPlayNext={() => {}}
+              onAdd={() => addToQueueBottom(createQueueItem(r, 'Spotify'))}
+              onPlayNext={() => addToQueueTop(createQueueItem(r, 'Spotify'))}
             />
           ))}
         {service === 'SoundCloud' &&
@@ -257,8 +275,8 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
               key={r.id}
               title={r.title}
               artist={r.artist}
-              onAdd={() => {}}
-              onPlayNext={() => {}}
+              onAdd={() => addToQueueBottom(createQueueItem(r, 'SoundCloud'))}
+              onPlayNext={() => addToQueueTop(createQueueItem(r, 'SoundCloud'))}
             />
           ))}
         <button


### PR DESCRIPTION
## Summary
- link queue state in App and pass down to `TopBar` and `RightSidebar`
- add callbacks in `TopBar` that create queue items and use play next / add buttons
- update `RightSidebar` to accept queue props

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850c6b66cf4832b88e39e54d19adbb4