### PR TITLE
Ensure queue items show album cover

### DIFF
--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -20,8 +20,18 @@ export default function SortableQueueItem({ id, item }) {
   };
 
   return (
-    <div ref={setNodeRef} style={style} className="queue-card" {...attributes} {...listeners}>
-      <div className="album-cover-placeholder" />
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="queue-card"
+      {...attributes}
+      {...listeners}
+    >
+      {item.albumCover ? (
+        <img src={item.albumCover} alt="album cover" className="album-cover" />
+      ) : (
+        <div className="album-cover-placeholder" />
+      )}
       <div className="song-info">
         <div className="song-title">{item.title}</div>
         <div className="artist-name">{item.artist}</div>


### PR DESCRIPTION
## Summary
- show the queue item's album cover image instead of a placeholder

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850d0d6bd38832bba9874ecdeb57c44