### PR TITLE
Connect queue state with backend

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -7,7 +7,7 @@ import {
 } from '@dnd-kit/sortable';
 import SortableQueueItem from './SortableQueueItem.jsx';
 
-export default function RightSidebar({ isVisible, queue, setQueue }) {
+export default function RightSidebar({ isVisible, queue, setQueue, onReorder }) {
   const [width, setWidth] = useState(300);
   const minWidth = 200;
   const maxWidth = 500;
@@ -42,6 +42,7 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
       setQueue((items) => {
         const oldIndex = items.findIndex((i) => i.id === active.id);
         const newIndex = items.findIndex((i) => i.id === over.id);
+        if (onReorder) onReorder(oldIndex, newIndex);
         return arrayMove(items, oldIndex, newIndex);
       });
     }

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -150,6 +150,8 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
     artist: result.artist,
     serviceLogo: serviceLogoMap[service],
     queuedBy: 'Pranav',
+    platform: service.toLowerCase(),
+    sourceId: result.id,
   });
 
   return (


### PR DESCRIPTION
## Summary
- modify queue item creation to include backend fields
- update RightSidebar to notify on reorder
- connect frontend queue actions to backend room APIs
- auto-create a Spotify room and fetch/delete rooms on load

## Testing
- `npm --prefix Harmonize run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850d453caec832b92725705e1bfd8a9