### PR TITLE
Add username modal and persistence

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -4,6 +4,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import RightSidebar from './components/RightSidebar';
 import UserCard from './components/UserCard';
 import RoomSetupModal from './components/RoomSetupModal.jsx';
+import UsernamePrompt from './components/UsernamePrompt.jsx';
 import YouTubeLogo from './assets/youtube.png';
 import SoundCloudLogo from './assets/soundcloud.svg';
 import SpotifyLogo from './assets/spotify.svg';
@@ -15,6 +16,8 @@ function App() {
   const minLeftWidth = 180;
   const maxLeftWidth = 400;
   const [showRoomModal, setShowRoomModal] = useState(true);
+  const [user, setUser] = useState(null);
+  const [showUserPrompt, setShowUserPrompt] = useState(false);
 
   const isResizingLeft = useRef(false);
 
@@ -41,6 +44,20 @@ function App() {
     };
   }, []);
 
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      try {
+        setUser(JSON.parse(stored));
+      } catch (err) {
+        console.error('Failed to parse stored user', err);
+        setShowUserPrompt(true);
+      }
+    } else {
+      setShowUserPrompt(true);
+    }
+  }, []);
+
   const songTitle = 'Song Name 🎵';
   const totalDuration = 200;
 
@@ -51,34 +68,15 @@ function App() {
 
   const progressBarRef = useRef(null);
 
-  const users = [
-    {
-      name: '🎧 Pranav (Admin)',
-      admin: true,
-      profilePic: 'https://via.placeholder.com/60',
-      services: ['Spotify', 'YouTube'],
-    },
-    {
-      name: 'Sofia',
-      profilePic: 'https://via.placeholder.com/60',
-      services: ['YouTube'],
-    },
-    {
-      name: 'Jake',
-      profilePic: 'https://via.placeholder.com/60',
-      services: ['SoundCloud', 'Spotify'],
-    },
-    {
-      name: 'Jess',
-      profilePic: 'https://via.placeholder.com/60',
-      services: ['SoundCloud'],
-    },
-    {
-      name: 'Zane',
-      profilePic: 'https://via.placeholder.com/60',
-      services: ['Spotify'],
-    },
-  ];
+  const users = user
+    ? [
+        {
+          name: user.username,
+          admin: false,
+          services: [],
+        },
+      ]
+    : [];
 
   const initialQueue = [];
 
@@ -125,8 +123,16 @@ function App() {
     setTimeout(() => setActiveButton(null), 200);
   };
 
+  const handleUserComplete = (data) => {
+    if (data) setUser(data);
+    setShowUserPrompt(false);
+  };
+
   return (
     <>
+      {showUserPrompt && (
+        <UsernamePrompt existingUser={user} onComplete={handleUserComplete} />
+      )}
       {showRoomModal && <RoomSetupModal onClose={() => setShowRoomModal(false)} />}
       <TopBar addToQueueTop={addToQueueTop} addToQueueBottom={addToQueueBottom} />
       <div className="app-layout">
@@ -148,6 +154,9 @@ function App() {
             <div className="sidebar-section">
               <h2 className="sidebar-title">Room: Harmonize HQ</h2>
               <button className="copy-button">Room Invite Link</button>
+              <button className="copy-button" onClick={() => setShowUserPrompt(true)}>
+                Change Username
+              </button>
             </div>
             <div className="sidebar-section">
               <h3 className="sidebar-subtitle">Listeners</h3>

--- a/Harmonize/src/components/UsernamePrompt.jsx
+++ b/Harmonize/src/components/UsernamePrompt.jsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+
+export default function UsernamePrompt({ onComplete, existingUser }) {
+  const [username, setUsername] = useState(existingUser?.username || '');
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') onComplete(null);
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onComplete]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmed = username.trim();
+    if (!trimmed) return;
+    try {
+      let userData;
+      if (existingUser) {
+        const res = await fetch(`/users/${existingUser.userId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username: trimmed }),
+        });
+        if (!res.ok) throw new Error('Failed to update');
+        userData = { userId: existingUser.userId, username: trimmed };
+      } else {
+        const res = await fetch('/users', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username: trimmed }),
+        });
+        if (!res.ok) throw new Error('Failed to create');
+        const data = await res.json();
+        userData = { userId: data.userId, username: data.username };
+      }
+      localStorage.setItem('user', JSON.stringify(userData));
+      onComplete(userData);
+    } catch (err) {
+      console.error('Username submission failed', err);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={() => onComplete(null)}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <button
+          className="modal-close-button"
+          onClick={() => onComplete(null)}
+          aria-label="Close Modal"
+        >
+          &times;
+        </button>
+        <h2 className="modal-title">
+          {existingUser ? 'Change Username' : 'Choose a Username'}
+        </h2>
+        <form onSubmit={handleSubmit} style={{ textAlign: 'center' }}>
+          <div className="unified-search-wrapper" style={{ maxWidth: '300px', margin: '0 auto' }}>
+            <input
+              type="text"
+              className="unified-search-input"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="Your name"
+              autoFocus
+            />
+          </div>
+          <button type="submit" className="submit-link-button" style={{ marginTop: '1rem' }}>
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `UsernamePrompt` modal component
- persist user credentials in localStorage after POST/PATCH to `/users`
- use stored user in `App.jsx` and show prompt if none
- allow changing username later via sidebar button
- derive listeners list from logged-in user

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f6c3b7c6c832b910a0271d1c90e03