### PR TITLE
Prefill room name with username

### DIFF
--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 export default function RoomSetupModal({ onClose }) {
   const [mode, setMode] = useState('name'); // 'name', 'choose', 'create', 'join'
@@ -10,6 +10,15 @@ export default function RoomSetupModal({ onClose }) {
     Spotify: true,
     SoundCloud: true,
   });
+  const defaultRoomName = userName ? `${userName}'s Listening Room` : '';
+  const roomNameInputRef = useRef(null);
+
+  // Set default room name when entering the create mode
+  useEffect(() => {
+    if (mode === 'create') {
+      setRoomName(defaultRoomName);
+    }
+  }, [mode, userName, defaultRoomName]);
 
   useEffect(() => {
     const handleKey = (e) => {
@@ -21,6 +30,12 @@ export default function RoomSetupModal({ onClose }) {
 
   const toggleService = (name) => {
     setServices((s) => ({ ...s, [name]: !s[name] }));
+  };
+
+  const handleRoomNameFocus = (e) => {
+    if (roomName === defaultRoomName) {
+      e.target.select();
+    }
   };
 
   return (
@@ -93,6 +108,8 @@ export default function RoomSetupModal({ onClose }) {
                 placeholder="Room Name"
                 value={roomName}
                 onChange={(e) => setRoomName(e.target.value)}
+                onFocus={handleRoomNameFocus}
+                ref={roomNameInputRef}
               />
             </div>
             <div className="service-checkboxes">


### PR DESCRIPTION
## Summary
- prefill the room name in RoomSetupModal with `<name>'s Listening Room`
- auto-select room name when input is focused so it's easy to edit

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f7e1211cc832bbfa012e6f9fee8eb