### PR TITLE
Disable continue until username typed

### DIFF
--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -52,6 +52,7 @@ export default function RoomSetupModal({ onClose }) {
                 <button
                   className="submit-link-button"
                   onClick={() => setMode('choose')}
+                  disabled={!userName.trim()}
                 >
                   Continue
                 </button>

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1196,6 +1196,12 @@ transform: scale(1.02);
   transform: scale(0.95);
 }
 
+.submit-link-button:disabled {
+  background-color: #999;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 /* Layout for the link modal input and button */
 .link-input-group {
   display: flex;


### PR DESCRIPTION
## Summary
- disable the continue button in the first modal screen until the username field is not empty
- style disabled continue button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f7db291d0832ba712cacba351fd7e