### PR TITLE
Add right-click delete option for queue items

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -12,6 +12,24 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
+  const [contextMenu, setContextMenu] = useState(null);
+
+  const handleContextMenu = (e, id) => {
+    e.preventDefault();
+    setContextMenu({ id, x: e.clientX, y: e.clientY });
+  };
+
+  const removeFromQueue = (id) => {
+    setQueue((q) => q.filter((item) => item.id !== id));
+    setContextMenu(null);
+  };
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = () => setContextMenu(null);
+    window.addEventListener('click', close);
+    return () => window.removeEventListener('click', close);
+  }, [contextMenu]);
 
   useEffect(() => {
     const handleMouseMove = (e) => {
@@ -78,10 +96,28 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
             strategy={verticalListSortingStrategy}
           >
             {queue.map((item) => (
-              <SortableQueueItem key={item.id} id={item.id} item={item} />
+              <SortableQueueItem
+                key={item.id}
+                id={item.id}
+                item={item}
+                onContextMenu={(e) => handleContextMenu(e, item.id)}
+              />
             ))}
           </SortableContext>
         </DndContext>
+      )}
+      {contextMenu && (
+        <div
+          className="context-menu"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          <button
+            className="delete-button"
+            onClick={() => removeFromQueue(contextMenu.id)}
+          >
+            Delete
+          </button>
+        </div>
       )}
     </div>
   );

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export default function SortableQueueItem({ id, item }) {
+export default function SortableQueueItem({ id, item, onContextMenu }) {
   const {
     attributes,
     listeners,
@@ -24,6 +24,7 @@ export default function SortableQueueItem({ id, item }) {
       ref={setNodeRef}
       style={style}
       className="queue-card"
+      onContextMenu={onContextMenu}
       {...attributes}
       {...listeners}
     >

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1265,3 +1265,26 @@ transform: scale(1.02);
   align-items: center;
   gap: 4px;
 }
+
+.context-menu {
+  position: fixed;
+  background-color: #1e1e1e;
+  border: 1px solid #333;
+  padding: 4px;
+  border-radius: 4px;
+  z-index: 1000;
+}
+
+.delete-button {
+  background-color: #444;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.delete-button:hover {
+  background-color: #ff4d4d;
+}


### PR DESCRIPTION
## Summary
- allow queue item right-click context menu to delete a song
- add context menu styles

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68609d1d19ac832baa6d5bfb757bb857