### PR TITLE
Enable removing songs via context menu

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -12,6 +12,7 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
+  const [contextMenu, setContextMenu] = useState(null);
 
   useEffect(() => {
     const handleMouseMove = (e) => {
@@ -36,6 +37,12 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
     };
   }, []);
 
+  useEffect(() => {
+    const handleClick = () => setContextMenu(null);
+    window.addEventListener('click', handleClick);
+    return () => window.removeEventListener('click', handleClick);
+  }, []);
+
   const handleDragEnd = (event) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
@@ -45,6 +52,16 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
         return arrayMove(items, oldIndex, newIndex);
       });
     }
+  };
+
+  const handleContextMenu = (e, id) => {
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY, id });
+  };
+
+  const removeFromQueue = (id) => {
+    setQueue((items) => items.filter((i) => i.id !== id));
+    setContextMenu(null);
   };
   return (
     <div
@@ -78,10 +95,28 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
             strategy={verticalListSortingStrategy}
           >
             {queue.map((item) => (
-              <SortableQueueItem key={item.id} id={item.id} item={item} />
+              <SortableQueueItem
+                key={item.id}
+                id={item.id}
+                item={item}
+                onContextMenu={(e) => handleContextMenu(e, item.id)}
+              />
             ))}
           </SortableContext>
         </DndContext>
+      )}
+      {contextMenu && (
+        <div
+          className="context-menu"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          <div
+            className="context-menu-item"
+            onClick={() => removeFromQueue(contextMenu.id)}
+          >
+            Remove from Queue
+          </div>
+        </div>
       )}
     </div>
   );

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export default function SortableQueueItem({ id, item }) {
+export default function SortableQueueItem({ id, item, onContextMenu }) {
   const {
     attributes,
     listeners,
@@ -24,6 +24,7 @@ export default function SortableQueueItem({ id, item }) {
       ref={setNodeRef}
       style={style}
       className="queue-card"
+      onContextMenu={onContextMenu}
       {...attributes}
       {...listeners}
     >

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -1265,3 +1265,23 @@ transform: scale(1.02);
   align-items: center;
   gap: 4px;
 }
+
+.context-menu {
+  position: fixed;
+  background-color: #222;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 4px 0;
+  z-index: 2000;
+  width: 150px;
+  color: white;
+}
+
+.context-menu-item {
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.context-menu-item:hover {
+  background-color: #555;
+}


### PR DESCRIPTION
## Summary
- add `onContextMenu` support to `SortableQueueItem`
- support context menu in `RightSidebar` to remove queue entries
- style the new context menu

## Testing
- `npm --prefix Harmonize run lint --silent`
- `npm test --silent`
- `npm --prefix Harmonize test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860a0d1f5f0832bb0fec76cd3c357b9