### PR TITLE
Add room name storage and display

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -16,6 +16,7 @@ function App() {
   const maxLeftWidth = 400;
   const [showRoomModal, setShowRoomModal] = useState(true);
   const [roomId, setRoomId] = useState(null);
+  const [roomName, setRoomName] = useState('');
 
   const isResizingLeft = useRef(false);
 
@@ -126,8 +127,9 @@ function App() {
     setTimeout(() => setActiveButton(null), 200);
   };
 
-  const handleRoomJoined = (id) => {
+  const handleRoomJoined = (id, name) => {
     setRoomId(id);
+    setRoomName(name || '');
     setShowRoomModal(false);
   };
 
@@ -157,7 +159,7 @@ function App() {
               onMouseDown={() => (isResizingLeft.current = true)}
             />
             <div className="sidebar-section">
-              <h2 className="sidebar-title">Room: {roomId || 'Not Connected'}</h2>
+              <h2 className="sidebar-title">Room: {roomName || 'Not Connected'}</h2>
               <button className="copy-button" disabled={!roomId}>Room Invite Link</button>
             </div>
             <div className="sidebar-section">

--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -83,12 +83,12 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
       const res = await fetch('http://localhost:3001/rooms/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'guest' })
+        body: JSON.stringify({ mode: 'guest', name: roomName })
       });
       const data = await res.json();
       if (res.ok) {
         await joinUserToRoom(data.roomId);
-        onRoomJoined?.(data.roomId);
+        onRoomJoined?.(data.roomId, data.roomName);
         onClose();
       } else {
         setError(data.error || 'Failed to create room');
@@ -108,7 +108,7 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
       const data = await res.json();
       if (res.ok) {
         await joinUserToRoom(roomCode);
-        onRoomJoined?.(roomCode);
+        onRoomJoined?.(roomCode, data.roomName);
         onClose();
       } else {
         setError(data.error || 'Room not found');

--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose'; // Get access to Mongoose
 // Define what a "Room" should look like in the database
 const RoomSchema = new mongoose.Schema({
   roomId: { type: String, required: true, unique: true }, // Short ID (e.g., abc123)
+  name: { type: String, required: true }, // Human friendly room name
   mode: { type: String, enum: ['guest', 'spotify'], required: true }, // Type of room
   createdAt: { type: Date, default: Date.now }, // Auto-record when the room was created
   users: [

--- a/backend/routes/rooms.js
+++ b/backend/routes/rooms.js
@@ -9,19 +9,19 @@ const router = express.Router(); // Create a new router for /rooms endpoints
 
 // POST /rooms/create
 router.post('/create', async (req, res) => {
-    const { mode } = req.body; // Get "mode" from the request body: 'guest' or 'spotify'
-  
+    const { mode, name } = req.body; // Get "mode" and room name
+
     // Generate a random 6-character room ID (like abc123)
     const roomId = crypto.randomBytes(3).toString('hex');
-  
+
     // Make a new room based on schema
-    const room = new Room({ roomId, mode });
-  
+    const room = new Room({ roomId, mode, name });
+
     // Save the room to the MongoDB database
     await room.save();
-  
+
     // Send back the room ID to the frontend
-    res.json({ roomId });
+    res.json({ roomId, roomName: room.name });
   });
   
 
@@ -29,11 +29,11 @@ router.post('/create', async (req, res) => {
 router.post('/:id/join', async (req, res) => {
     const roomId = req.params.id; // Get the room ID from the URL
     const room = await Room.findOne({ roomId }); // Look it up in the database
-  
+
     if (!room) return res.status(404).json({ error: 'Room not found' }); // Error if not found
-  
+
     // You could add logic here to track users in the room
-    res.json({ message: 'Joined room', mode: room.mode }); // Send back confirmation
+    res.json({ message: 'Joined room', mode: room.mode, roomName: room.name }); // Send back confirmation
   });
   
   


### PR DESCRIPTION
## Summary
- add `name` property to `Room` model
- return and store room names when creating or joining rooms
- show room name in the left sidebar

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860ac638ee0832ba47be3ba2e8fd0b5