### PR TITLE
Update room mode from service selection

### DIFF
--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -80,10 +80,11 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
   const handleCreate = async () => {
     setError('');
     try {
+      const roomMode = services.Spotify ? 'spotify' : 'guest';
       const res = await fetch('http://localhost:3001/rooms/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'guest' })
+        body: JSON.stringify({ mode: roomMode })
       });
       const data = await res.json();
       if (res.ok) {


### PR DESCRIPTION
## Summary
- derive room `mode` in RoomSetupModal from Spotify checkbox selection

## Testing
- `npm run lint --silent` in `Harmonize`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860ad2d4d20832bbf4afcca69050b7f