### PR TITLE
Persist user session across reloads

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -40,6 +40,18 @@ function App() {
     };
   }, []);
 
+  useEffect(() => {
+    const savedRoomId = localStorage.getItem('roomId');
+    const savedUserId = localStorage.getItem('userId');
+    if (savedRoomId && savedUserId) {
+      setRoomId(savedRoomId);
+      setRoomName(localStorage.getItem('roomName') || '');
+      setCurrentUserId(savedUserId);
+      setShowRoomModal(false);
+      fetchRoomUsers(savedRoomId);
+    }
+  }, []);
+
   const songTitle = 'Song Name 🎵';
   const totalDuration = 200;
 
@@ -110,11 +122,15 @@ function App() {
     }
   };
 
-  const handleRoomJoined = (id, name, uid) => {
+  const handleRoomJoined = (id, name, uid, uname) => {
     setRoomId(id);
     setRoomName(name || '');
     setCurrentUserId(uid);
     setShowRoomModal(false);
+    localStorage.setItem('roomId', id);
+    localStorage.setItem('roomName', name || '');
+    localStorage.setItem('userId', uid);
+    if (uname) localStorage.setItem('userName', uname);
     fetchRoomUsers(id);
   };
 

--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -15,6 +15,13 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
   const defaultRoomName = userName ? `${userName}'s Listening Room` : '';
   const roomNameInputRef = useRef(null);
 
+  useEffect(() => {
+    const savedName = localStorage.getItem('userName');
+    const savedId = localStorage.getItem('userId');
+    if (savedName) setUserName(savedName);
+    if (savedId) setUserId(savedId);
+  }, []);
+
   // Set default room name when entering the create mode
   useEffect(() => {
     if (mode === 'create') {
@@ -48,6 +55,8 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
       const data = await res.json();
       if (res.ok) {
         setUserId(data.userId);
+        localStorage.setItem('userId', data.userId);
+        localStorage.setItem('userName', userName);
         setMode('choose');
       } else {
         setError(data.error || 'Failed to create user');
@@ -88,7 +97,7 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
       const data = await res.json();
       if (res.ok) {
         await joinUserToRoom(data.roomId);
-        onRoomJoined?.(data.roomId, data.roomName, userId);
+        onRoomJoined?.(data.roomId, data.roomName, userId, userName);
         onClose();
       } else {
         setError(data.error || 'Failed to create room');
@@ -108,7 +117,7 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
       const data = await res.json();
       if (res.ok) {
         await joinUserToRoom(roomCode);
-        onRoomJoined?.(roomCode, data.roomName, userId);
+        onRoomJoined?.(roomCode, data.roomName, userId, userName);
         onClose();
       } else {
         setError(data.error || 'Room not found');


### PR DESCRIPTION
## Summary
- persist user session and room info in localStorage
- preload saved values on startup
- retain userName and userId in RoomSetupModal

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860be340120832bb75693f69d9e05e5