### PR TITLE
Update room creation mode logic

### DIFF
--- a/Harmonize/src/components/RoomSetupModal.jsx
+++ b/Harmonize/src/components/RoomSetupModal.jsx
@@ -88,11 +88,12 @@ export default function RoomSetupModal({ onClose, onRoomJoined }) {
 
   const handleCreate = async () => {
     setError('');
+    const mode = services.Spotify ? 'spotify' : 'guest';
     try {
       const res = await fetch('http://localhost:3001/rooms/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'guest', name: roomName })
+        body: JSON.stringify({ mode, name: roomName })
       });
       const data = await res.json();
       if (res.ok) {

--- a/backend/routes/rooms.js
+++ b/backend/routes/rooms.js
@@ -9,7 +9,8 @@ const router = express.Router(); // Create a new router for /rooms endpoints
 
 // POST /rooms/create
 router.post('/create', async (req, res) => {
-    const { mode, name } = req.body; // Get "mode" and room name
+    const { mode: requestedMode, name } = req.body; // Get requested mode and room name
+    const mode = requestedMode === 'spotify' ? 'spotify' : 'guest';
 
     // Generate a random 6-character room ID (like abc123)
     const roomId = crypto.randomBytes(3).toString('hex');


### PR DESCRIPTION
## Summary
- set room mode based on Spotify checkbox on the frontend
- default the backend room mode to `guest` unless `spotify` is requested

## Testing
- `npm run lint` in `Harmonize`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860c3e6bd74832bbf03d8dee9f05580