### PR TITLE
Add admin label

### DIFF
--- a/Harmonize/src/components/UserCard.jsx
+++ b/Harmonize/src/components/UserCard.jsx
@@ -37,14 +37,20 @@ export default function UserCard({ user, isCurrent }) {
         <div className="head"></div>
         <div className="body"></div>
       </div>
-      <span className="username">{user.username}</span>
+      <span className="username">
+        {user.username}
+        {user.isAdmin && ' (Admin)'}
+      </span>
       {open && (
         <div className="contact-card" onPointerDown={(e) => e.stopPropagation()}>
           <div className="contact-icon">
             <div className="head"></div>
             <div className="body"></div>
           </div>
-          <div className="contact-name">{user.username}</div>
+          <div className="contact-name">
+            {user.username}
+            {user.isAdmin && ' (Admin)'}
+          </div>
           <div className="contact-services">
             {user.services.map((s) => (
               <img


### PR DESCRIPTION
## Summary
- show `(Admin)` next to admin usernames in user list and contact card

## Testing
- `npm run lint` in `Harmonize/`
- `npm test` in `backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860d9429584832ba6aca7a4629c67bb