### PR TITLE
Center service logo above username

### DIFF
--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -839,7 +839,10 @@ transform: scale(1.02);
 }
 
 .service-info {
-  text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
   font-size: 12px;
 }
 


### PR DESCRIPTION
## Summary
- center the service logo over the user name on queue cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860dd9626e0832bb586500956f3f642