### PR TITLE
Add context menu for queue item deletion

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -12,6 +12,7 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
+  const [contextMenu, setContextMenu] = useState(null);
 
   useEffect(() => {
     const handleMouseMove = (e) => {
@@ -36,6 +37,12 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
     };
   }, []);
 
+  useEffect(() => {
+    const closeMenu = () => setContextMenu(null);
+    window.addEventListener('click', closeMenu);
+    return () => window.removeEventListener('click', closeMenu);
+  }, []);
+
   const handleDragEnd = (event) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
@@ -45,6 +52,16 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
         return arrayMove(items, oldIndex, newIndex);
       });
     }
+  };
+
+  const handleContextMenu = (e, id) => {
+    e.preventDefault();
+    setContextMenu({ mouseX: e.clientX, mouseY: e.clientY, id });
+  };
+
+  const handleDelete = (id) => {
+    setQueue((items) => items.filter((i) => i.id !== id));
+    setContextMenu(null);
   };
   return (
     <div
@@ -78,10 +95,23 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
             strategy={verticalListSortingStrategy}
           >
             {queue.map((item) => (
-              <SortableQueueItem key={item.id} id={item.id} item={item} />
+              <SortableQueueItem
+                key={item.id}
+                id={item.id}
+                item={item}
+                onRightClick={handleContextMenu}
+              />
             ))}
           </SortableContext>
         </DndContext>
+      )}
+      {contextMenu && (
+        <div
+          className="queue-context-menu"
+          style={{ top: contextMenu.mouseY, left: contextMenu.mouseX }}
+        >
+          <button onClick={() => handleDelete(contextMenu.id)}>Delete</button>
+        </div>
       )}
     </div>
   );

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -19,12 +19,10 @@ export default function SortableQueueItem({ id, item, onRightClick }) {
     cursor: isDragging ? 'grabbing' : 'grab',
   };
 
-  const handleMouseDown = (e) => {
-    if (e.button === 2) {
-      e.preventDefault();
-      e.stopPropagation();
-      onRightClick?.(e, id);
-    }
+  const handleContextMenu = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onRightClick?.(e, id);
   };
 
   return (
@@ -32,10 +30,9 @@ export default function SortableQueueItem({ id, item, onRightClick }) {
       ref={setNodeRef}
       style={style}
       className="queue-card"
-      onContextMenu={(e) => e.preventDefault()}
-      onMouseDown={handleMouseDown}
       {...attributes}
       {...listeners}
+      onContextMenu={handleContextMenu}
     >
       {item.albumCover ? (
         <img src={item.albumCover} alt="album cover" className="album-cover" />

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -19,12 +19,21 @@ export default function SortableQueueItem({ id, item, onRightClick }) {
     cursor: isDragging ? 'grabbing' : 'grab',
   };
 
+  const handleMouseDown = (e) => {
+    if (e.button === 2) {
+      e.preventDefault();
+      e.stopPropagation();
+      onRightClick?.(e, id);
+    }
+  };
+
   return (
     <div
       ref={setNodeRef}
       style={style}
       className="queue-card"
-      onContextMenu={(e) => onRightClick?.(e, id)}
+      onContextMenu={(e) => e.preventDefault()}
+      onMouseDown={handleMouseDown}
       {...attributes}
       {...listeners}
     >

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export default function SortableQueueItem({ id, item }) {
+export default function SortableQueueItem({ id, item, onRightClick }) {
   const {
     attributes,
     listeners,
@@ -24,6 +24,7 @@ export default function SortableQueueItem({ id, item }) {
       ref={setNodeRef}
       style={style}
       className="queue-card"
+      onContextMenu={(e) => onRightClick?.(e, id)}
       {...attributes}
       {...listeners}
     >

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -795,6 +795,29 @@ transform: scale(1.02);
   cursor: grabbing;
 }
 
+.queue-context-menu {
+  position: fixed;
+  background-color: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 4px;
+  z-index: 1000;
+}
+
+.queue-context-menu button {
+  background: none;
+  border: none;
+  color: white;
+  padding: 4px 8px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+
+.queue-context-menu button:hover {
+  background-color: #333;
+}
+
 .result-card {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- allow queue items to receive right-clicks
- track and display custom context menu in `RightSidebar`
- delete queue items via context menu
- style context menu button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860e49881cc832b9713022d013dba8c