### PR TITLE
Add swipe-to-delete and vertical drag lock for queue

### DIFF
--- a/Harmonize/package-lock.json
+++ b/Harmonize/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "debug": "^4.4.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-swipeable": "^7.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -348,6 +350,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {
@@ -2524,6 +2540,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/resolve-from": {

--- a/Harmonize/package.json
+++ b/Harmonize/package.json
@@ -11,11 +11,13 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "debug": "^4.4.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-swipeable": "^7.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { DndContext, closestCenter } from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -72,13 +73,24 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
           Empty Queue, Search or Add Links to Starting Listening
         </div>
       ) : (
-        <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+          modifiers={[restrictToVerticalAxis]}
+        >
           <SortableContext
             items={queue.map((q) => q.id)}
             strategy={verticalListSortingStrategy}
           >
             {queue.map((item) => (
-              <SortableQueueItem key={item.id} id={item.id} item={item} />
+              <SortableQueueItem
+                key={item.id}
+                id={item.id}
+                item={item}
+                onDelete={() =>
+                  setQueue((items) => items.filter((i) => i.id !== item.id))
+                }
+              />
             ))}
           </SortableContext>
         </DndContext>

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useSwipeable } from 'react-swipeable';
 
-export default function SortableQueueItem({ id, item }) {
+export default function SortableQueueItem({ id, item, onDelete }) {
   const {
     attributes,
     listeners,
@@ -11,6 +12,14 @@ export default function SortableQueueItem({ id, item }) {
     transition,
     isDragging,
   } = useSortable({ id });
+
+  const [showDelete, setShowDelete] = useState(false);
+
+  const handlers = useSwipeable({
+    onSwipedLeft: () => setShowDelete(true),
+    onSwipedRight: () => setShowDelete(true),
+    trackMouse: true,
+  });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -26,6 +35,7 @@ export default function SortableQueueItem({ id, item }) {
       className="queue-card"
       {...attributes}
       {...listeners}
+      {...handlers}
     >
       {item.albumCover ? (
         <img src={item.albumCover} alt="album cover" className="album-cover" />
@@ -44,6 +54,11 @@ export default function SortableQueueItem({ id, item }) {
         />
         <div className="queued-by">{item.queuedBy}</div>
       </div>
+      {showDelete && (
+        <button className="delete-button" onClick={onDelete}>
+          Delete
+        </button>
+      )}
     </div>
   );
 }

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -772,6 +772,7 @@ transform: scale(1.02);
 }
 
 .queue-card {
+  position: relative;
   display: flex;
   align-items: center;
   background-color: #1E1E1E;
@@ -793,6 +794,23 @@ transform: scale(1.02);
   transform: scale(0.98);
   background-color: #3b3b3b;
   cursor: grabbing;
+}
+
+.delete-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 80px;
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  border-radius: 0 6px 6px 0;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  background-color: #c0392b;
 }
 
 .result-card {


### PR DESCRIPTION
## Summary
- add @dnd-kit/modifiers and react-swipeable deps
- lock queue drag movement to vertical axis
- allow queue items to be swiped left or right to reveal a delete button
- style delete button overlay

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860ef7f5c00832b891c990d53bd28b6