### PR TITLE
Implement queue delete mode

### DIFF
--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -9,7 +9,8 @@ import SortableQueueItem from './SortableQueueItem.jsx';
 
 export default function RightSidebar({ isVisible, queue, setQueue }) {
   const [width, setWidth] = useState(300);
-  const [deleteMode, setDeleteMode] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState(new Set());
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
@@ -48,9 +49,28 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
     }
   };
 
-  const toggleDeleteMode = () => setDeleteMode((prev) => !prev);
-  const handleDeleteItem = (id) =>
-    setQueue((items) => items.filter((i) => i.id !== id));
+  const toggleSelectMode = () => {
+    setSelectMode((prev) => !prev);
+    setSelectedIds(new Set());
+  };
+
+  const handleSelectItem = (id) => {
+    setSelectedIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(id)) {
+        newSet.delete(id);
+      } else {
+        newSet.add(id);
+      }
+      return newSet;
+    });
+  };
+
+  const handleDeleteSelected = () => {
+    setQueue((items) => items.filter((i) => !selectedIds.has(i.id)));
+    setSelectedIds(new Set());
+    setSelectMode(false);
+  };
   return (
     <div
       className="right-sidebar"
@@ -70,8 +90,11 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
 
       <div className="sidebar-section queue-header">
         <h2 className="sidebar-title">Shared Queue</h2>
-        <button className="copy-button" onClick={toggleDeleteMode}>
-          {deleteMode ? 'Finish Deleting' : 'Delete Tracks'}
+        <button
+          className="copy-button queue-select-button"
+          onClick={selectMode ? handleDeleteSelected : toggleSelectMode}
+        >
+          {selectMode ? 'Delete' : 'Select'}
         </button>
       </div>
 
@@ -93,8 +116,9 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
                 key={item.id}
                 id={item.id}
                 item={item}
-                deleteMode={deleteMode}
-                onDelete={handleDeleteItem}
+                selectMode={selectMode}
+                selected={selectedIds.has(item.id)}
+                onSelect={handleSelectItem}
               />
             ))}
           </SortableContext>

--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -9,6 +9,7 @@ import SortableQueueItem from './SortableQueueItem.jsx';
 
 export default function RightSidebar({ isVisible, queue, setQueue }) {
   const [width, setWidth] = useState(300);
+  const [deleteMode, setDeleteMode] = useState(false);
   const minWidth = 200;
   const maxWidth = 500;
   const isResizing = useRef(false);
@@ -46,6 +47,10 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
       });
     }
   };
+
+  const toggleDeleteMode = () => setDeleteMode((prev) => !prev);
+  const handleDeleteItem = (id) =>
+    setQueue((items) => items.filter((i) => i.id !== id));
   return (
     <div
       className="right-sidebar"
@@ -63,8 +68,11 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
         style={{ display: isVisible ? 'block' : 'none' }}
       />
 
-      <div className="sidebar-section">
+      <div className="sidebar-section queue-header">
         <h2 className="sidebar-title">Shared Queue</h2>
+        <button className="copy-button" onClick={toggleDeleteMode}>
+          {deleteMode ? 'Finish Deleting' : 'Delete Tracks'}
+        </button>
       </div>
 
       {queue.length === 0 ? (
@@ -72,13 +80,22 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
           Empty Queue, Search or Add Links to Starting Listening
         </div>
       ) : (
-        <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
           <SortableContext
             items={queue.map((q) => q.id)}
             strategy={verticalListSortingStrategy}
           >
             {queue.map((item) => (
-              <SortableQueueItem key={item.id} id={item.id} item={item} />
+              <SortableQueueItem
+                key={item.id}
+                id={item.id}
+                item={item}
+                deleteMode={deleteMode}
+                onDelete={handleDeleteItem}
+              />
             ))}
           </SortableContext>
         </DndContext>

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export default function SortableQueueItem({ id, item, deleteMode, onDelete }) {
+export default function SortableQueueItem({
+  id,
+  item,
+  selectMode,
+  selected,
+  onSelect,
+}) {
   const {
     attributes,
     listeners,
@@ -10,13 +16,13 @@ export default function SortableQueueItem({ id, item, deleteMode, onDelete }) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id, disabled: deleteMode });
+  } = useSortable({ id, disabled: selectMode });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    cursor: deleteMode ? 'pointer' : isDragging ? 'grabbing' : 'grab',
+    cursor: selectMode ? 'pointer' : isDragging ? 'grabbing' : 'grab',
   };
 
   return (
@@ -24,9 +30,9 @@ export default function SortableQueueItem({ id, item, deleteMode, onDelete }) {
       ref={setNodeRef}
       style={style}
       className="queue-card"
-      {...(!deleteMode && attributes)}
-      {...(!deleteMode && listeners)}
-      onClick={deleteMode ? () => onDelete(id) : undefined}
+      {...(!selectMode && attributes)}
+      {...(!selectMode && listeners)}
+      onClick={selectMode ? () => onSelect(id) : undefined}
     >
       {item.albumCover ? (
         <img src={item.albumCover} alt="album cover" className="album-cover" />
@@ -37,14 +43,18 @@ export default function SortableQueueItem({ id, item, deleteMode, onDelete }) {
         <div className="song-title">{item.title}</div>
         <div className="artist-name">{item.artist}</div>
       </div>
-      <div className="service-info">
-        <img
-          src={item.serviceLogo}
-          alt="service"
-          style={{ width: 20, height: 20, marginBottom: 4 }}
-        />
-        <div className="queued-by">{item.queuedBy}</div>
-      </div>
+      {selectMode ? (
+        <div className={`checkbox ${selected ? 'checked' : ''}`} />
+      ) : (
+        <div className="service-info">
+          <img
+            src={item.serviceLogo}
+            alt="service"
+            style={{ width: 20, height: 20, marginBottom: 4 }}
+          />
+          <div className="queued-by">{item.queuedBy}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/Harmonize/src/components/SortableQueueItem.jsx
+++ b/Harmonize/src/components/SortableQueueItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export default function SortableQueueItem({ id, item }) {
+export default function SortableQueueItem({ id, item, deleteMode, onDelete }) {
   const {
     attributes,
     listeners,
@@ -10,13 +10,13 @@ export default function SortableQueueItem({ id, item }) {
     transform,
     transition,
     isDragging,
-  } = useSortable({ id });
+  } = useSortable({ id, disabled: deleteMode });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    cursor: isDragging ? 'grabbing' : 'grab',
+    cursor: deleteMode ? 'pointer' : isDragging ? 'grabbing' : 'grab',
   };
 
   return (
@@ -24,8 +24,9 @@ export default function SortableQueueItem({ id, item }) {
       ref={setNodeRef}
       style={style}
       className="queue-card"
-      {...attributes}
-      {...listeners}
+      {...(!deleteMode && attributes)}
+      {...(!deleteMode && listeners)}
+      onClick={deleteMode ? () => onDelete(id) : undefined}
     >
       {item.albumCover ? (
         <img src={item.albumCover} alt="album cover" className="album-cover" />

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -162,6 +162,12 @@ html, body {
     font-family: 'Roboto', sans-serif;
     transition: background-color 0.2s ease, border-color 0.2s ease;
   }
+
+  .queue-select-button {
+    min-width: 80px;
+    transition: background-color 0.2s ease, border-color 0.2s ease,
+      width 0.2s ease;
+  }
   
   .copy-button:hover {
     background-color: #112240;         /* slightly lighter navy on hover */
@@ -799,6 +805,27 @@ transform: scale(1.02);
   transform: scale(0.98);
   background-color: #3b3b3b;
   cursor: grabbing;
+}
+
+.checkbox {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #3b82f6;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+}
+
+.checkbox.checked {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.checkbox.checked::after {
+  content: '\2713';
+  font-size: 16px;
 }
 
 .result-card {

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -765,6 +765,12 @@ transform: scale(1.02);
   position: relative;
 }
 
+.queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .empty-queue-message {
   text-align: center;
   color: #ccc;

--- a/Harmonize/src/styles.css
+++ b/Harmonize/src/styles.css
@@ -824,7 +824,7 @@ transform: scale(1.02);
 }
 
 .checkbox.checked::after {
-  content: '\2713';
+  content: '\2715';
   font-size: 16px;
 }
 


### PR DESCRIPTION
## Summary
- add a toggle button beside Shared Queue title
- implement delete mode in RightSidebar and SortableQueueItem
- add queue-header styles

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867542f07f8832b840ebcc012b791fc