### PR TITLE
Implement backend queue update

### DIFF
--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -149,12 +149,12 @@ function App() {
       if (res.ok) {
         const keepKeys = new Set();
         const mapped = await Promise.all(
-          data.queue.map(async (q, index) => {
+          data.queue.map(async (q) => {
             const key = `${q.platform}:${q.sourceId}`;
             keepKeys.add(key);
             const albumCover = await getAlbumCover(q.platform, q.sourceId);
             return {
-              id: q.sourceId || `${q.title}-${index}`,
+              id: `pos-${q.position}`,
               albumCover,
               title: q.title,
               artist: q.artist,

--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -164,6 +164,7 @@ function App() {
                 (users.find((u) => u.userId === q.addedBy)?.username || 'Unknown'),
               platform: q.platform,
               sourceId: q.sourceId,
+              position: q.position,
             };
           })
         );
@@ -450,6 +451,8 @@ function App() {
           isVisible={isRightSidebarVisible}
           queue={queue}
           setQueue={setQueue}
+          roomId={roomId}
+          fetchRoomQueue={fetchRoomQueue}
         />
       </div>
 

--- a/Harmonize/src/App.jsx
+++ b/Harmonize/src/App.jsx
@@ -89,8 +89,36 @@ function App() {
   const [showConfirmLeave, setShowConfirmLeave] = useState(false);
   const [roomEnded, setRoomEnded] = useState(false);
 
-  const addToQueueTop = (item) => setQueue((prev) => [item, ...prev]);
-  const addToQueueBottom = (item) => setQueue((prev) => [...prev, item]);
+  const sendSong = async (song, playNext = false) => {
+    if (!roomId || !currentUserId) return;
+    const endpoint = playNext
+      ? `http://localhost:3001/rooms/${roomId}/queue/next`
+      : `http://localhost:3001/rooms/${roomId}/queue`;
+    try {
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: song.title,
+          artist: song.artist,
+          platform: song.platform,
+          sourceId: song.sourceId,
+          addedBy: currentUserId,
+        }),
+      });
+    } catch (err) {
+      console.error('Queue song error', err);
+    }
+  };
+
+  const addToQueueTop = (item) => {
+    setQueue((prev) => [item, ...prev]);
+    sendSong(item, true);
+  };
+  const addToQueueBottom = (item) => {
+    setQueue((prev) => [...prev, item]);
+    sendSong(item, false);
+  };
 
   const handleSeekStart = (e) => {
     setIsSeeking(true);

--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -7,7 +7,13 @@ import {
 } from '@dnd-kit/sortable';
 import SortableQueueItem from './SortableQueueItem.jsx';
 
-export default function RightSidebar({ isVisible, queue, setQueue }) {
+export default function RightSidebar({
+  isVisible,
+  queue,
+  setQueue,
+  roomId,
+  fetchRoomQueue,
+}) {
   const [width, setWidth] = useState(300);
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState(new Set());
@@ -66,10 +72,24 @@ export default function RightSidebar({ isVisible, queue, setQueue }) {
     });
   };
 
-  const handleDeleteSelected = () => {
-    setQueue((items) => items.filter((i) => !selectedIds.has(i.id)));
+  const handleDeleteSelected = async () => {
+    if (!roomId) return;
+    const itemsToDelete = queue
+      .filter((i) => selectedIds.has(i.id))
+      .sort((a, b) => b.position - a.position);
+    for (const item of itemsToDelete) {
+      try {
+        await fetch(
+          `http://localhost:3001/rooms/${roomId}/queue/${item.position}`,
+          { method: 'DELETE' }
+        );
+      } catch (err) {
+        console.error('Delete queue item error', err);
+      }
+    }
     setSelectedIds(new Set());
     setSelectMode(false);
+    fetchRoomQueue(roomId);
   };
   return (
     <div

--- a/Harmonize/src/components/RightSidebar.jsx
+++ b/Harmonize/src/components/RightSidebar.jsx
@@ -44,14 +44,29 @@ export default function RightSidebar({
     };
   }, []);
 
-  const handleDragEnd = (event) => {
+  const handleDragEnd = async (event) => {
     const { active, over } = event;
-    if (over && active.id !== over.id) {
-      setQueue((items) => {
-        const oldIndex = items.findIndex((i) => i.id === active.id);
-        const newIndex = items.findIndex((i) => i.id === over.id);
-        return arrayMove(items, oldIndex, newIndex);
-      });
+    if (!over || active.id === over.id) return;
+
+    let oldIndex;
+    let newIndex;
+    setQueue((items) => {
+      oldIndex = items.findIndex((i) => i.id === active.id);
+      newIndex = items.findIndex((i) => i.id === over.id);
+      return arrayMove(items, oldIndex, newIndex);
+    });
+
+    if (roomId != null) {
+      try {
+        await fetch(`http://localhost:3001/rooms/${roomId}/queue/reorder`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sourceIndex: oldIndex, destinationIndex: newIndex }),
+        });
+      } catch (err) {
+        console.error('Reorder queue error', err);
+      }
+      fetchRoomQueue(roomId);
     }
   };
 

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -4,7 +4,7 @@ import YouTubeLogo from '../assets/youtube.png';
 import SoundCloudLogo from '../assets/soundcloud.svg';
 import SpotifyLogo from '../assets/spotify.svg';
 
-export default function TopBar({ addToQueueTop, addToQueueBottom }) {
+export default function TopBar({ addToQueueTop, addToQueueBottom, users, currentUserId }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [linkInput, setLinkInput] = useState('');
@@ -143,13 +143,18 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
     SoundCloud: SoundCloudLogo,
   };
 
+  const getCurrentUserName = () => {
+    const user = users.find((u) => u.userId === currentUserId);
+    return user?.username || 'Unknown';
+  };
+
   const createQueueItem = (result, service) => ({
     id: Date.now().toString(),
     albumCover: result.thumbnail || 'https://via.placeholder.com/60',
     title: result.title,
     artist: result.artist,
     serviceLogo: serviceLogoMap[service],
-    queuedBy: localStorage.getItem('userName') || 'Unknown',
+    queuedBy: getCurrentUserName(),
     platform: service.toLowerCase(),
     sourceId: result.id || null,
   });

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -170,7 +170,12 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
       if (!data.error) {
         addToQueueBottom(
           createQueueItem(
-            { title: data.title, artist: data.artist, thumbnail: data.thumbnail },
+            {
+              id: data.id,
+              title: data.title,
+              artist: data.artist,
+              thumbnail: data.thumbnail,
+            },
             data.service
           )
         );

--- a/Harmonize/src/components/TopBar.jsx
+++ b/Harmonize/src/components/TopBar.jsx
@@ -149,7 +149,9 @@ const activeServices = ['YouTube', 'Spotify', 'SoundCloud']; // 👈 change this
     title: result.title,
     artist: result.artist,
     serviceLogo: serviceLogoMap[service],
-    queuedBy: 'Pranav',
+    queuedBy: localStorage.getItem('userName') || 'Unknown',
+    platform: service.toLowerCase(),
+    sourceId: result.id || null,
   });
 
   const handleLinkSubmit = async () => {

--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -20,6 +20,7 @@ const RoomSchema = new mongoose.Schema({
       platform: String,     // 'spotify', 'youtube', 'soundcloud'
       sourceId: String,     // Spotify URI, YouTube video ID, etc.
       addedBy: String,       // username or user ID
+      addedByName: String,   // display name of the user who queued the song
       position: Number
     }
 ]

--- a/backend/routes/resolve.js
+++ b/backend/routes/resolve.js
@@ -41,6 +41,7 @@ router.get('/', async (req, res) => {
       if (!item) return res.status(404).json({ error: 'Video not found' });
       const result = {
         service: 'YouTube',
+        id: videoId,
         title: item.snippet.title,
         artist: item.snippet.channelTitle,
         thumbnail: item.snippet.thumbnails?.default?.url || null,
@@ -62,6 +63,7 @@ router.get('/', async (req, res) => {
       const thumbnail = data.album?.images?.[data.album.images.length - 1]?.url || null;
       const result = {
         service: 'Spotify',
+        id,
         title: data.name,
         artist: data.artists.map((a) => a.name).join(', '),
         thumbnail,

--- a/backend/routes/rooms.js
+++ b/backend/routes/rooms.js
@@ -75,6 +75,7 @@ router.get('/:id/queue', async (req, res) => {
         platform,
         sourceId,
         addedBy,
+        addedByName: user.username,
         position: room.queue.length
       };
   
@@ -310,6 +311,7 @@ router.post('/:id/queue/next', async (req, res) => {
       platform,
       sourceId,
       addedBy,
+      addedByName: user.username,
       position: insertIndex
     });
 

--- a/backend/routes/spotify.js
+++ b/backend/routes/spotify.js
@@ -50,4 +50,21 @@ router.get('/search', async (req, res) => {
   }
 });
 
+router.get('/track/:id', async (req, res) => {
+  const id = req.params.id;
+  try {
+    const token = await getAccessToken();
+    const resp = await fetch(`https://api.spotify.com/v1/tracks/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await resp.json();
+    if (data.error) return res.status(400).json({ error: 'Track not found' });
+    const thumbnail = data.album?.images?.[data.album.images.length - 1]?.url || null;
+    res.json({ thumbnail });
+  } catch (err) {
+    console.error('Spotify track error', err);
+    res.status(500).json({ error: 'Failed to fetch track' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- include username with queued songs in Room model
- store username when adding songs to queue
- record queue changes from the frontend
- send track details to backend when queuing songs

## Testing
- `npm run lint --prefix Harmonize` *(fails: Cannot find package '@eslint/js')*
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68675b0b8a88832b858ee09ed0dcf1fa