### PR TITLE
Add admin YouTube player with queue advancing

### DIFF
--- a/Harmonize/src/components/YouTubePlayer.jsx
+++ b/Harmonize/src/components/YouTubePlayer.jsx
@@ -1,0 +1,54 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function YouTubePlayer({ videoId, onEnded }) {
+  const containerRef = useRef(null);
+  const playerRef = useRef(null);
+
+  useEffect(() => {
+    if (!videoId) return;
+
+    const load = () => {
+      if (window.YT && window.YT.Player) {
+        createPlayer();
+      } else {
+        const tag = document.createElement('script');
+        tag.src = 'https://www.youtube.com/iframe_api';
+        window.onYouTubeIframeAPIReady = createPlayer;
+        document.body.appendChild(tag);
+      }
+    };
+
+    const createPlayer = () => {
+      if (playerRef.current) {
+        playerRef.current.destroy();
+      }
+      playerRef.current = new window.YT.Player(containerRef.current, {
+        videoId,
+        events: {
+          onStateChange: (e) => {
+            if (e.data === window.YT.PlayerState.ENDED) {
+              onEnded && onEnded();
+            }
+          }
+        }
+      });
+    };
+
+    load();
+
+    return () => {
+      if (playerRef.current) {
+        playerRef.current.destroy();
+        playerRef.current = null;
+      }
+    };
+  }, [videoId, onEnded]);
+
+  useEffect(() => {
+    if (playerRef.current && videoId) {
+      playerRef.current.loadVideoById(videoId);
+    }
+  }, [videoId]);
+
+  return <div ref={containerRef}></div>;
+}

--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -23,7 +23,20 @@ const RoomSchema = new mongoose.Schema({
       addedByName: String,   // display name of the user who queued the song
       position: Number
     }
-]
+  ],
+  // Songs that have been played already. Used for seeking backwards
+  history: [
+    {
+      title: String,
+      artist: String,
+      platform: String,
+      sourceId: String,
+      addedBy: String,
+      addedByName: String
+    }
+  ],
+  // Index of the currently playing song in the history array
+  currentIndex: { type: Number, default: -1 }
 });
 
 


### PR DESCRIPTION
## Summary
- store history of played songs in Room model and track currentIndex
- add `/rooms/:id/next` and `/rooms/:id/prev` endpoints to move songs between queue and history
- create `YouTubePlayer` React component using YouTube iframe API
- update frontend to automatically play YouTube songs for admins and adjust queue

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && npm test` *(fails: Error: no test specified)*
- `cd ../Harmonize && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68785f91935c832ba5f88d005e2cae7e