### PR TITLE
Implement currentPlaying index tracking

### DIFF
--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -24,7 +24,8 @@ const RoomSchema = new mongoose.Schema({
       position: Number
     }
   ],
-  currentIndex: { type: Number, default: -1 } // Index of the currently playing song
+  currentIndex: { type: Number, default: -1 }, // Index of the currently playing song
+  currentPlaying: { type: Number, default: -1 } // Track the song playing for all users
 });
 
 

--- a/backend/routes/rooms.js
+++ b/backend/routes/rooms.js
@@ -180,6 +180,18 @@ router.get('/:id/current-index', async (req, res) => {
   }
 });
 
+// GET /rooms/:id/current-playing → fetch the current playing index
+router.get('/:id/current-playing', async (req, res) => {
+  try {
+    const room = await Room.findOne({ roomId: req.params.id });
+    if (!room) return res.status(404).json({ error: 'Room not found' });
+    res.json({ currentPlaying: room.currentPlaying });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // PATCH /rooms/:id/current-index → update the currently playing index
 router.patch('/:id/current-index', async (req, res) => {
   const { index } = req.body;
@@ -190,6 +202,25 @@ router.patch('/:id/current-index', async (req, res) => {
       room.currentIndex = index;
       await room.save();
       res.json({ message: 'Current index updated', currentIndex: room.currentIndex });
+    } else {
+      res.status(400).json({ error: 'Invalid index' });
+    }
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// PATCH /rooms/:id/current-playing → update the current playing index
+router.patch('/:id/current-playing', async (req, res) => {
+  const { index } = req.body;
+  try {
+    const room = await Room.findOne({ roomId: req.params.id });
+    if (!room) return res.status(404).json({ error: 'Room not found' });
+    if (typeof index === 'number') {
+      room.currentPlaying = index;
+      await room.save();
+      res.json({ message: 'Current playing updated', currentPlaying: room.currentPlaying });
     } else {
       res.status(400).json({ error: 'Invalid index' });
     }


### PR DESCRIPTION
## Summary
- track the song currently playing with new `currentPlaying` field
- expose `current-playing` API endpoints for rooms
- sync new state from the frontend and update when skipping songs
- display current song details on the Now Playing section

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68884f574810832b98199de6f1274c13