### PR TITLE
Add queue timeOfSong migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ SPOTIFY_REDIRECT_URI=<Spotify OAuth redirect URI>
 The `.env` file is excluded from version control via the root `.gitignore`.
 An example file `backend/.env.example` is provided to illustrate the expected
 variables.
+
+## Migrating existing data
+
+If upgrading from an earlier version, queue entries may not have a `timeOfSong` field.
+Run the migration script to add this field:
+
+```bash
+node backend/scripts/fixTimeOfSong.js
+```
+
+This sets `timeOfSong` to `null` for any songs missing the field.

--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -22,7 +22,7 @@ const RoomSchema = new mongoose.Schema({
       addedBy: String,       // username or user ID
       addedByName: String,   // display name of the user who queued the song
       position: Number,
-      timeOfSong: Number // Unix timestamp when the song started playing
+      timeOfSong: { type: Number, default: null } // Unix timestamp when the song started playing
     }
   ],
   currentIndex: { type: Number, default: -1 }, // Index of the currently playing song

--- a/backend/scripts/fixTimeOfSong.js
+++ b/backend/scripts/fixTimeOfSong.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import Room from '../models/Room.js';
+
+// Load environment variables from backend/.env
+dotenv.config({ path: new URL('../.env', import.meta.url).pathname });
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  });
+
+  const rooms = await Room.find();
+  for (const room of rooms) {
+    let updated = false;
+    room.queue.forEach((item) => {
+      if (item.timeOfSong === undefined) {
+        item.timeOfSong = null;
+        updated = true;
+      }
+    });
+    if (updated) {
+      await room.save();
+      console.log(`Updated room ${room.roomId}`);
+    }
+  }
+  await mongoose.disconnect();
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- default `timeOfSong` in queue items so the field always exists
- provide a script to backfill missing `timeOfSong` values
- document upgrade step for existing installs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688858b84678832bbd66c87fed9c64da