### PR TITLE
Prevent YouTube player from tearing down React container

### DIFF
--- a/Harmonize/src/components/YouTubePlayer.jsx
+++ b/Harmonize/src/components/YouTubePlayer.jsx
@@ -3,6 +3,10 @@ import React, { useEffect, useRef } from 'react';
 export default function YouTubePlayer({ videoId, playing }) {
   const containerRef = useRef(null);
   const playerRef = useRef(null);
+  // Separate DOM node for the YouTube API so destroying the player doesn't
+  // remove the React-managed container element. This avoids a DOM mismatch
+  // error when React later tries to unmount the component.
+  const playerContainerRef = useRef(null);
 
   useEffect(() => {
     // Load the YouTube Iframe API if it hasn't been loaded yet
@@ -24,13 +28,25 @@ export default function YouTubePlayer({ videoId, playing }) {
         playerRef.current.destroy();
         playerRef.current = null;
       }
+      // Ensure the dynamically created player container is removed so the
+      // outer React element remains in place for React to unmount safely.
+      if (playerContainerRef.current) {
+        playerContainerRef.current.remove();
+        playerContainerRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const createPlayer = () => {
     if (playerRef.current || !containerRef.current) return;
-    playerRef.current = new window.YT.Player(containerRef.current, {
+    // Lazily create a child node for the YouTube player if it doesn't exist
+    if (!playerContainerRef.current) {
+      playerContainerRef.current = document.createElement('div');
+      containerRef.current.appendChild(playerContainerRef.current);
+    }
+
+    playerRef.current = new window.YT.Player(playerContainerRef.current, {
       videoId,
       height: '100%',
       width: '100%',


### PR DESCRIPTION
## Summary
- isolate YouTube IFrame API into its own DOM node so destroying the player doesn't remove the React-managed element
- clean up the dynamically-created player container on unmount to avoid DOM mismatches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688e98320694832bba19ab4b0ae02ea9