### PR TITLE
Remove obsolete currentIndex field

### DIFF
--- a/backend/models/Room.js
+++ b/backend/models/Room.js
@@ -26,10 +26,10 @@ const RoomSchema = new mongoose.Schema({
       durationSec: { type: Number, default: null } // Length of the track in seconds
     }
   ],
-  currentIndex: { type: Number, default: -1 }, // Index of the currently playing song
   currentPlaying: { type: Number, default: -1 } // Track the song playing for all users
 });
 
 
 // Export this model so we can use it in our routes
 export default mongoose.model('Room', RoomSchema);
+

--- a/backend/routes/rooms.js
+++ b/backend/routes/rooms.js
@@ -228,43 +228,11 @@ router.delete('/:id/queue/:position', async (req, res) => {
   });
 
 
-// GET /rooms/:id/current-index → fetch the currently playing index
-router.get('/:id/current-index', async (req, res) => {
-  try {
-    const room = await Room.findOne({ roomId: req.params.id });
-    if (!room) return res.status(404).json({ error: 'Room not found' });
-    res.json({ currentIndex: room.currentIndex });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-// GET /rooms/:id/current-playing → fetch the current playing index
 router.get('/:id/current-playing', async (req, res) => {
   try {
     const room = await Room.findOne({ roomId: req.params.id });
     if (!room) return res.status(404).json({ error: 'Room not found' });
     res.json({ currentPlaying: room.currentPlaying });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal server error' });
-  }
-});
-
-// PATCH /rooms/:id/current-index → update the currently playing index
-router.patch('/:id/current-index', async (req, res) => {
-  const { index } = req.body;
-  try {
-    const room = await Room.findOne({ roomId: req.params.id });
-    if (!room) return res.status(404).json({ error: 'Room not found' });
-    if (typeof index === 'number') {
-      room.currentIndex = index;
-      await room.save();
-      res.json({ message: 'Current index updated', currentIndex: room.currentIndex });
-    } else {
-      res.status(400).json({ error: 'Invalid index' });
-    }
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Internal server error' });
@@ -429,7 +397,7 @@ router.post('/:id/queue/next', async (req, res) => {
       return res.status(400).json({ error: 'Spotify songs are not allowed in guest mode' });
     }
 
-    const insertIndex = room.currentIndex + 1 || 0;
+    const insertIndex = room.currentPlaying + 1 || 0;
 
     const durationSec = await fetchDuration(platform, sourceId);
 
@@ -459,7 +427,5 @@ router.post('/:id/queue/next', async (req, res) => {
   }
 });
 
-
-
-  
 export default router;
+

--- a/backend/scripts/removeCurrentIndex.js
+++ b/backend/scripts/removeCurrentIndex.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import Room from '../models/Room.js';
+
+// Load environment variables from backend/.env
+dotenv.config({ path: new URL('../.env', import.meta.url).pathname });
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  });
+
+  await Room.updateMany({}, { $unset: { currentIndex: "" } });
+  console.log('Removed currentIndex from all rooms');
+
+  await mongoose.disconnect();
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- drop `currentIndex` from Room schema and API routes
- base queue "play next" insertion on `currentPlaying`
- add maintenance script to remove `currentIndex` from existing documents

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fd88d5f1c832b990eeb54312b1f2d