### PR TITLE
Fix: Vercel routing for client-side sublinks\n\nUpdated vercel.json t…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,24 @@
-{ "version": 2, "builds": [ { "src": "client/package.json", "use": "@vercel/static-build", "config": { "distDir": "client/build" } }, { "src": "api/index.js", "use": "@vercel/node" } ], "routes": [ { "src": "/api/(.*)", "dest": "/api/index.js" }, { "src": "/(.*)", "dest": "/client/$1" } ] }
+{
+    "version": 2,
+    "builds": [
+      {
+        "src": "client/package.json",
+        "use": "@vercel/static-build",
+        "config": { "distDir": "client/build" }
+      },
+      {
+        "src": "api/index.js",
+        "use": "@vercel/node"
+      }
+    ],
+    "routes": [
+      {
+        "src": "/api/(.*)",
+        "dest": "/api/index.js"
+      },
+      {
+        "src": "/(.*)",
+        "dest": "/index.html"
+      }
+    ]
+  }


### PR DESCRIPTION
…o route all non-API requests to index.html for proper client-side routing.